### PR TITLE
Pass *http.Request to view factory function

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -94,7 +94,7 @@ func (v *CounterView) HandleEvent(event string, _ gl.Payload) error {
 }
 
 func main() {
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &CounterView{} }))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &CounterView{} }))
 	log.Fatal(http.ListenAndServe(":8840", nil))
 }
 ```

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ func (v *CounterView) HandleEvent(event string, _ gl.Payload) error {
 }
 
 func main() {
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &CounterView{} }))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &CounterView{} }))
 	log.Fatal(http.ListenAndServe(":8840", nil))
 }
 ```

--- a/example/admin/TUTORIAL.ja.md
+++ b/example/admin/TUTORIAL.ja.md
@@ -589,7 +589,7 @@ func main() {
         opts = append(opts, gl.WithDebug())
     }
 
-    http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &AdminView{} }, opts...))
+    http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &AdminView{} }, opts...))
     log.Printf("admin running on %s", *addr)
     log.Fatal(http.ListenAndServe(*addr, nil))
 }
@@ -597,7 +597,7 @@ func main() {
 
 サーバーのセットアップは最小限です:
 
-- **`gl.Handler(factory, opts...)`** は初期 HTML を配信し、ライブ更新のために WebSocket にアップグレードする HTTP ハンドラを作成。ファクトリ関数 `func(_ *http.Request) gl.View { return &AdminView{} }` は各セッションに新しい `AdminView` を生成。`*http.Request` パラメータにより、ミドルウェアで設定した認証ユーザーなどのリクエストコンテキストにアクセス可能
+- **`gl.Handler(factory, opts...)`** は初期 HTML を配信し、ライブ更新のために WebSocket にアップグレードする HTTP ハンドラを作成。ファクトリ関数 `func(_ context.Context) gl.View { return &AdminView{} }` は各セッションに新しい `AdminView` を生成。`context.Context` パラメータにより、ミドルウェアで設定した認証ユーザーなどのリクエストスコープの値にアクセス可能
 - **`gl.WithDebug()`** はデバッグパネルを有効化し、ブラウザで WebSocket メッセージ、イベントペイロード、レンダリングタイミングを確認可能
 
 ## 動作の仕組み

--- a/example/admin/TUTORIAL.md
+++ b/example/admin/TUTORIAL.md
@@ -589,7 +589,7 @@ func main() {
         opts = append(opts, gl.WithDebug())
     }
 
-    http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &AdminView{} }, opts...))
+    http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &AdminView{} }, opts...))
     log.Printf("admin running on %s", *addr)
     log.Fatal(http.ListenAndServe(*addr, nil))
 }
@@ -597,7 +597,7 @@ func main() {
 
 The server setup is minimal:
 
-- **`gl.Handler(factory, opts...)`** creates an HTTP handler that serves the initial HTML and upgrades to WebSocket for live updates. The factory function `func(_ *http.Request) gl.View { return &AdminView{} }` creates a fresh `AdminView` for each session. The `*http.Request` parameter allows the factory to access request context (e.g. authenticated user set by middleware).
+- **`gl.Handler(factory, opts...)`** creates an HTTP handler that serves the initial HTML and upgrades to WebSocket for live updates. The factory function `func(_ context.Context) gl.View { return &AdminView{} }` creates a fresh `AdminView` for each session. The `context.Context` parameter carries request-scoped values (e.g. authenticated user set by middleware).
 - **`gl.WithDebug()`** enables the debug panel, which shows WebSocket messages, event payloads, and render timing in the browser.
 
 ## How It Works

--- a/example/admin/admin.go
+++ b/example/admin/admin.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -522,7 +523,7 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &AdminView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &AdminView{} }, opts...))
 	log.Printf("admin running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/catalog/catalog.go
+++ b/example/catalog/catalog.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -1918,7 +1919,7 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &CatalogView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &CatalogView{} }, opts...))
 	log.Printf("catalog running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/clock/TUTORIAL.ja.md
+++ b/example/clock/TUTORIAL.ja.md
@@ -178,7 +178,7 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &ClockView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &ClockView{} }, opts...))
 	log.Printf("clock running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/clock/TUTORIAL.md
+++ b/example/clock/TUTORIAL.md
@@ -178,7 +178,7 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &ClockView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &ClockView{} }, opts...))
 	log.Printf("clock running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/clock/clock.go
+++ b/example/clock/clock.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -118,7 +119,7 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &ClockView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &ClockView{} }, opts...))
 	log.Printf("clock running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/counter/TUTORIAL.ja.md
+++ b/example/counter/TUTORIAL.ja.md
@@ -110,14 +110,14 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &CounterView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &CounterView{} }, opts...))
 	log.Printf("counter running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }
 ```
 
 - `gl.Handler(factory)` は初期 HTML レンダリングと WebSocket 接続の両方を処理する `http.Handler` を返します
-- ファクトリ関数 `func(*http.Request) gl.View` はセッションごとに呼ばれ、新しい `View` インスタンスを生成します — リクエストからコンテキスト値（認証済みユーザーなど）にアクセス可能
+- ファクトリ関数 `func(context.Context) gl.View` はセッションごとに呼ばれ、新しい `View` インスタンスを生成します — コンテキストにはミドルウェアで設定したリクエストスコープの値（認証済みユーザーなど）が含まれます
 - オプション: `gl.WithLang("en")` で HTML の lang 属性を設定、`gl.WithSessionTTL(10*time.Minute)` でセッションタイムアウトを調整
 - `gl.WithDebug()` でブラウザ DevPanel とサーバーサイド構造化ログを有効化（後述）
 

--- a/example/counter/TUTORIAL.md
+++ b/example/counter/TUTORIAL.md
@@ -110,14 +110,14 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &CounterView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &CounterView{} }, opts...))
 	log.Printf("counter running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }
 ```
 
 - `gl.Handler(factory)` returns an `http.Handler` that handles both initial HTTP rendering and WebSocket connections
-- The factory function `func(*http.Request) gl.View` is called once per session to create a fresh `View` instance — the request is available for accessing context values (e.g. authenticated user)
+- The factory function `func(context.Context) gl.View` is called once per session to create a fresh `View` instance — the context carries request-scoped values (e.g. authenticated user set by middleware)
 - Options: `gl.WithLang("en")` sets the HTML lang attribute, `gl.WithSessionTTL(10*time.Minute)` adjusts the session timeout
 - `gl.WithDebug()` enables the browser DevPanel and server-side structured logging (see below)
 

--- a/example/counter/counter.go
+++ b/example/counter/counter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -53,7 +54,7 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &CounterView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &CounterView{} }, opts...))
 	log.Printf("counter running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/jscommand/jscommand.go
+++ b/example/jscommand/jscommand.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -211,7 +212,7 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &JSCommandView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &JSCommandView{} }, opts...))
 	log.Printf("jscommand running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/mdviewer/TUTORIAL.ja.md
+++ b/example/mdviewer/TUTORIAL.ja.md
@@ -305,7 +305,7 @@ func main() {
     debug := flag.Bool("debug", false, "enable debug panel")
     flag.Parse()
 
-    factory := func(_ *http.Request) gl.View {
+    factory := func(_ context.Context) gl.View {
         return &MarkdownView{
             FilePath: filePath,
             Preview:  *preview,

--- a/example/mdviewer/TUTORIAL.md
+++ b/example/mdviewer/TUTORIAL.md
@@ -305,7 +305,7 @@ func main() {
     debug := flag.Bool("debug", false, "enable debug panel")
     flag.Parse()
 
-    factory := func(_ *http.Request) gl.View {
+    factory := func(_ context.Context) gl.View {
         return &MarkdownView{
             FilePath: filePath,
             Preview:  *preview,

--- a/example/mdviewer/main.go
+++ b/example/mdviewer/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -42,7 +43,7 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	factory := func(_ *http.Request) gl.View {
+	factory := func(_ context.Context) gl.View {
 		return &MarkdownView{
 			FilePath: filePath,
 			Preview:  *preview,

--- a/example/tabview/TUTORIAL.ja.md
+++ b/example/tabview/TUTORIAL.ja.md
@@ -149,7 +149,7 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &TabDemoView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &TabDemoView{} }, opts...))
 	log.Printf("tabview running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/tabview/TUTORIAL.md
+++ b/example/tabview/TUTORIAL.md
@@ -149,7 +149,7 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &TabDemoView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &TabDemoView{} }, opts...))
 	log.Printf("tabview running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/tabview/tabview.go
+++ b/example/tabview/tabview.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -110,7 +111,7 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &TabDemoView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &TabDemoView{} }, opts...))
 	log.Printf("tabview running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/upload/upload.go
+++ b/example/upload/upload.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -162,7 +163,7 @@ func main() {
 		opts = append(opts, gl.WithDebug())
 	}
 
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &UploadView{} }, opts...))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &UploadView{} }, opts...))
 	log.Printf("upload running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/wiki_live/TUTORIAL.ja.md
+++ b/example/wiki_live/TUTORIAL.ja.md
@@ -303,7 +303,7 @@ func (v *WikiView) renderEdit() g.ComponentFunc {
 func main() {
 	addr := flag.String("addr", ":8850", "listen address")
 	flag.Parse()
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &WikiView{} }))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &WikiView{} }))
 	log.Printf("wiki_live running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/wiki_live/TUTORIAL.md
+++ b/example/wiki_live/TUTORIAL.md
@@ -303,7 +303,7 @@ func (v *WikiView) renderEdit() g.ComponentFunc {
 func main() {
 	addr := flag.String("addr", ":8850", "listen address")
 	flag.Parse()
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &WikiView{} }))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &WikiView{} }))
 	log.Printf("wiki_live running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/example/wiki_live/wiki_live.go
+++ b/example/wiki_live/wiki_live.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -241,7 +242,7 @@ func (v *WikiView) renderEdit() g.ComponentFunc {
 func main() {
 	addr := flag.String("addr", ":8850", "listen address")
 	flag.Parse()
-	http.Handle("/", gl.Handler(func(_ *http.Request) gl.View { return &WikiView{} }))
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &WikiView{} }))
 	log.Printf("wiki_live running on %s", *addr)
 	log.Fatal(http.ListenAndServe(*addr, nil))
 }

--- a/live/debug_test.go
+++ b/live/debug_test.go
@@ -1,9 +1,9 @@
 package live
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -22,7 +22,7 @@ func TestWithDebugOption(t *testing.T) {
 }
 
 func TestDebugHTTPInjectsDebugScript(t *testing.T) {
-	h := Handler(func(_ *http.Request) View { return &testView{} }, WithDebug())
+	h := Handler(func(_ context.Context) View { return &testView{} }, WithDebug())
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -35,7 +35,7 @@ func TestDebugHTTPInjectsDebugScript(t *testing.T) {
 }
 
 func TestNonDebugHTTPDoesNotInjectDebugScript(t *testing.T) {
-	h := Handler(func(_ *http.Request) View { return &testView{} })
+	h := Handler(func(_ context.Context) View { return &testView{} })
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)

--- a/live/handler.go
+++ b/live/handler.go
@@ -1,6 +1,7 @@
 package live
 
 import (
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
@@ -78,9 +79,9 @@ func defaultCheckOrigin(r *http.Request) bool {
 
 // Handler returns an http.Handler for a LiveView.
 // viewFactory is called once per session to create a new View instance.
-// The *http.Request is passed so the factory can access request context
-// (e.g. authenticated user set by middleware).
-func Handler(viewFactory func(*http.Request) View, opts ...Option) http.Handler {
+// The context.Context carries request-scoped values (e.g. authenticated user
+// set by middleware via r.Context()).
+func Handler(viewFactory func(context.Context) View, opts ...Option) http.Handler {
 	cfg := &handlerConfig{
 		lang:       "ja",
 		sessionTTL: 5 * time.Minute,
@@ -122,8 +123,8 @@ func Handler(viewFactory func(*http.Request) View, opts ...Option) http.Handler 
 	return handler
 }
 
-func handleHTTP(w http.ResponseWriter, r *http.Request, viewFactory func(*http.Request) View, store *sessionStore, cfg *handlerConfig, dlog *debugLogger) {
-	view := viewFactory(r)
+func handleHTTP(w http.ResponseWriter, r *http.Request, viewFactory func(context.Context) View, store *sessionStore, cfg *handlerConfig, dlog *debugLogger) {
+	view := viewFactory(r.Context())
 
 	params := make(Params)
 	for k, v := range r.URL.Query() {

--- a/live/handler_test.go
+++ b/live/handler_test.go
@@ -1,6 +1,7 @@
 package live
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +41,7 @@ func (v *testView) HandleEvent(event string, payload Payload) error {
 }
 
 func TestHandlerHTTPRender(t *testing.T) {
-	h := Handler(func(_ *http.Request) View { return &testView{} })
+	h := Handler(func(_ context.Context) View { return &testView{} })
 
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
@@ -71,7 +72,7 @@ func TestHandlerHTTPRender(t *testing.T) {
 }
 
 func TestHandlerHTTPContentType(t *testing.T) {
-	h := Handler(func(_ *http.Request) View { return &testView{} })
+	h := Handler(func(_ context.Context) View { return &testView{} })
 
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
@@ -84,7 +85,7 @@ func TestHandlerHTTPContentType(t *testing.T) {
 }
 
 func TestHandlerWSWithoutSession(t *testing.T) {
-	h := Handler(func(_ *http.Request) View { return &testView{} })
+	h := Handler(func(_ context.Context) View { return &testView{} })
 
 	req := httptest.NewRequest("GET", "/?gerbera-ws=1&session=invalid", nil)
 	w := httptest.NewRecorder()
@@ -96,7 +97,7 @@ func TestHandlerWSWithoutSession(t *testing.T) {
 }
 
 func TestHandlerWithLang(t *testing.T) {
-	h := Handler(func(_ *http.Request) View { return &testView{} }, WithLang("en"))
+	h := Handler(func(_ context.Context) View { return &testView{} }, WithLang("en"))
 
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
@@ -226,7 +227,7 @@ func TestBuildTreeWithCSRFToken(t *testing.T) {
 }
 
 func TestCSRFTokenInResponse(t *testing.T) {
-	h := Handler(func(_ *http.Request) View { return &testView{} })
+	h := Handler(func(_ context.Context) View { return &testView{} })
 
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
@@ -255,7 +256,7 @@ func TestCSRFTokenDiffersFromSession(t *testing.T) {
 }
 
 func TestWSRejectsWithoutCSRF(t *testing.T) {
-	h := Handler(func(_ *http.Request) View { return &testView{} })
+	h := Handler(func(_ context.Context) View { return &testView{} })
 
 	// First, create a session via HTTP
 	req := httptest.NewRequest("GET", "/", nil)
@@ -283,7 +284,7 @@ func TestWSRejectsWithoutCSRF(t *testing.T) {
 }
 
 func TestWSRejectsWithWrongCSRF(t *testing.T) {
-	h := Handler(func(_ *http.Request) View { return &testView{} })
+	h := Handler(func(_ context.Context) View { return &testView{} })
 
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
@@ -309,7 +310,7 @@ func TestWSRejectsWithWrongCSRF(t *testing.T) {
 }
 
 func TestUploadRejectsWithoutCSRF(t *testing.T) {
-	h := Handler(func(_ *http.Request) View { return &testView{} })
+	h := Handler(func(_ context.Context) View { return &testView{} })
 
 	// Create a session
 	req := httptest.NewRequest("GET", "/", nil)
@@ -385,26 +386,25 @@ func TestWithCheckOriginOption(t *testing.T) {
 	}
 }
 
-func TestHandlerPassesRequestToFactory(t *testing.T) {
-	var receivedReq *http.Request
+type ctxKey string
 
-	h := Handler(func(r *http.Request) View {
-		receivedReq = r
+func TestHandlerPassesContextToFactory(t *testing.T) {
+	var receivedCtx context.Context
+
+	h := Handler(func(ctx context.Context) View {
+		receivedCtx = ctx
 		return &testView{}
 	})
 
-	req := httptest.NewRequest("GET", "/?user=alice", nil)
-	req.Header.Set("X-Custom-Header", "test-value")
+	ctx := context.WithValue(context.Background(), ctxKey("user"), "alice")
+	req := httptest.NewRequest("GET", "/", nil).WithContext(ctx)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
-	if receivedReq == nil {
-		t.Fatal("expected factory to receive *http.Request, got nil")
+	if receivedCtx == nil {
+		t.Fatal("expected factory to receive context.Context, got nil")
 	}
-	if receivedReq.URL.Query().Get("user") != "alice" {
-		t.Errorf("expected query param user=alice, got %s", receivedReq.URL.Query().Get("user"))
-	}
-	if receivedReq.Header.Get("X-Custom-Header") != "test-value" {
-		t.Errorf("expected header X-Custom-Header=test-value, got %s", receivedReq.Header.Get("X-Custom-Header"))
+	if receivedCtx.Value(ctxKey("user")) != "alice" {
+		t.Errorf("expected context value user=alice, got %v", receivedCtx.Value(ctxKey("user")))
 	}
 }

--- a/live/new_features_test.go
+++ b/live/new_features_test.go
@@ -1,6 +1,7 @@
 package live
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -399,7 +400,7 @@ func TestWithMiddleware(t *testing.T) {
 		})
 	}
 
-	h := Handler(func(_ *http.Request) View { return &testView{} }, WithMiddleware(mw))
+	h := Handler(func(_ context.Context) View { return &testView{} }, WithMiddleware(mw))
 
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

Closes #12

- Change `live.Handler()` factory function signature from `func() View` to `func(context.Context) View` (breaking change)
- Factory receives `r.Context()` so it can access request-scoped values (e.g. authenticated user set by middleware)
- Query parameters are already available via `Mount(params Params)`, so `*http.Request` is unnecessary — `context.Context` is the idiomatic Go approach
- Update all 9 example files, 14 documentation files, and 3 test files
- Add `TestHandlerPassesContextToFactory` to verify context values are passed through

### Usage

```go
// コンテキスト不要な場合
http.Handle("/", gl.Handler(func(_ context.Context) gl.View {
    return &CounterView{}
}, opts...))

// 認証コンテキストを利用する場合
http.Handle("/dashboard", gl.Handler(func(ctx context.Context) gl.View {
    user := ctx.Value(authUserKey).(*User)
    return &DashboardView{User: user}
}, gl.WithMiddleware(authMiddleware)))
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + new test)
- [x] Verify example apps start correctly (`go run example/counter/counter.go`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)