### PR TITLE
Add session.Broker and SessionExpiredHandler (Issue #14)

### DIFF
--- a/example/auth/auth.go
+++ b/example/auth/auth.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -9,17 +10,29 @@ import (
 	g "github.com/tomo3110/gerbera"
 	gd "github.com/tomo3110/gerbera/dom"
 	"github.com/tomo3110/gerbera/expr"
+	gl "github.com/tomo3110/gerbera/live"
 	gp "github.com/tomo3110/gerbera/property"
 	"github.com/tomo3110/gerbera/session"
 	gu "github.com/tomo3110/gerbera/ui"
 )
 
-func dashboardPage(r *http.Request) []g.ComponentFunc {
-	sess := session.FromContext(r.Context())
-	username := ""
-	if sess != nil {
-		username = sess.GetString("username")
+// DashboardView is a LiveView that shows the authenticated user's dashboard.
+// It implements SessionExpiredHandler to gracefully handle session invalidation
+// (e.g. logout from another tab) by redirecting to the login page.
+type DashboardView struct {
+	gl.CommandQueue
+	Username       string
+	SessionExpired bool
+}
+
+func (v *DashboardView) Mount(params gl.Params) error {
+	if params.Conn.Session != nil {
+		v.Username = params.Conn.Session.GetString("username")
 	}
+	return nil
+}
+
+func (v *DashboardView) Render() []g.ComponentFunc {
 	return []g.ComponentFunc{
 		gd.Head(
 			gd.Title("Auth Demo"),
@@ -29,10 +42,25 @@ func dashboardPage(r *http.Request) []g.ComponentFunc {
 			gu.ContainerNarrow(
 				gu.Stack(
 					gd.H1(gp.Value("Auth Demo")),
+					expr.If(v.SessionExpired,
+						gu.Card(
+							gu.CardBody(
+								gp.Attr("style", "border-color: var(--g-warning-border); background: var(--g-warning-bg)"),
+								gd.P(
+									gp.Attr("style", "color: var(--g-warning); margin: 0"),
+									gp.Value("Session expired. Redirecting to login..."),
+								),
+							),
+						),
+					),
 					gu.Card(
-						gu.CardHeader(fmt.Sprintf("Welcome, %s!", username)),
+						gu.CardHeader(fmt.Sprintf("Welcome, %s!", v.Username)),
 						gu.CardBody(
-							gd.P(gp.Value("You are logged in. This page is protected by session middleware.")),
+							gd.P(gp.Value("You are logged in. This page is a LiveView protected by session middleware.")),
+							gd.P(
+								gp.Attr("style", "color: var(--g-text-secondary); font-size: 0.9em"),
+								gp.Value("Try logging out from another tab to see push-based session invalidation."),
+							),
 						),
 						gu.CardFooter(
 							gd.A(gp.Attr("href", "/logout"),
@@ -44,6 +72,18 @@ func dashboardPage(r *http.Request) []g.ComponentFunc {
 			),
 		),
 	}
+}
+
+func (v *DashboardView) HandleEvent(event string, payload gl.Payload) error {
+	return nil
+}
+
+// OnSessionExpired is called by the Broker when the session is invalidated.
+// It shows a notification and navigates the client to the login page.
+func (v *DashboardView) OnSessionExpired() error {
+	v.SessionExpired = true
+	v.Navigate("/login")
+	return nil
 }
 
 func loginFormPage(r *http.Request) []g.ComponentFunc {
@@ -174,6 +214,7 @@ func logoutHandler(w http.ResponseWriter, r *http.Request, store session.Store) 
 
 func main() {
 	addr := flag.String("addr", ":8895", "listen address")
+	debug := flag.Bool("debug", false, "enable debug panel")
 	flag.Parse()
 
 	key := []byte("example-secret-key-change-in-prod")
@@ -198,8 +239,16 @@ func main() {
 		logoutHandler(w, r, store)
 	})
 
-	// GET / — protected dashboard page using g.HandlerFunc
-	mux.Handle("/", authGuard(g.HandlerFunc(dashboardPage)))
+	// GET / — protected LiveView dashboard with session invalidation support
+	liveOpts := []gl.Option{
+		gl.WithSessionStore(store),
+	}
+	if *debug {
+		liveOpts = append(liveOpts, gl.WithDebug())
+	}
+	mux.Handle("/", authGuard(gl.Handler(func(ctx context.Context) gl.View {
+		return &DashboardView{}
+	}, liveOpts...)))
 
 	handler := sessionMW(mux)
 

--- a/live/gerbera.js
+++ b/live/gerbera.js
@@ -366,6 +366,9 @@
         case "toggle":
           if (el) el.style.display = el.style.display === "none" ? "" : "none";
           break;
+        case "navigate":
+          if (cmd.args && cmd.args.url) location.href = cmd.args.url;
+          break;
       }
     });
   }

--- a/live/handler.go
+++ b/live/handler.go
@@ -19,11 +19,12 @@ import (
 )
 
 type handlerConfig struct {
-	lang        string
-	sessionTTL  time.Duration
-	debug       bool
-	middlewares []func(http.Handler) http.Handler
-	checkOrigin func(r *http.Request) bool
+	lang         string
+	sessionTTL   time.Duration
+	debug        bool
+	middlewares  []func(http.Handler) http.Handler
+	checkOrigin  func(r *http.Request) bool
+	sessionStore session.Store
 }
 
 // Option configures the live handler.
@@ -57,6 +58,14 @@ func WithMiddleware(mw func(http.Handler) http.Handler) Option {
 // By default, the Origin header is validated against the request Host.
 func WithCheckOrigin(fn func(r *http.Request) bool) Option {
 	return func(c *handlerConfig) { c.checkOrigin = fn }
+}
+
+// WithSessionStore sets the session store for push-based session invalidation.
+// If the store implements session.BrokerStore, WebSocket connections will
+// automatically subscribe to session invalidation events and close when
+// the session is destroyed or expires.
+func WithSessionStore(store session.Store) Option {
+	return func(c *handlerConfig) { c.sessionStore = store }
 }
 
 type wsEvent struct {
@@ -228,6 +237,16 @@ func handleWS(w http.ResponseWriter, r *http.Request, store *sessionStore, cfg *
 		}
 	}
 
+	// Subscribe to session invalidation if BrokerStore is available
+	var invalidatedCh <-chan struct{}
+	if httpSess := session.FromContext(r.Context()); httpSess != nil {
+		if bs, ok := cfg.sessionStore.(session.BrokerStore); ok {
+			ch, unsub := bs.Broker().Subscribe(httpSess.ID)
+			defer unsub()
+			invalidatedCh = ch
+		}
+	}
+
 	var wsMu sync.Mutex // protects conn.WriteJSON
 
 	for {
@@ -319,6 +338,23 @@ func handleWS(w http.ResponseWriter, r *http.Request, store *sessionStore, cfg *
 			if err != nil {
 				return
 			}
+
+		case <-invalidatedCh:
+			// Session was invalidated (logout or expiry)
+			if h, ok := sess.View.(SessionExpiredHandler); ok {
+				sess.mu.Lock()
+				h.OnSessionExpired()
+				patches, jsCommands, viewState, err := renderAndDiff(sess, cfg)
+				sess.mu.Unlock()
+				if err == nil {
+					wsMu.Lock()
+					sendPatches(conn, patches, jsCommands, viewState, cfg, dlog, sessionID, "session_expired", nil, 0)
+					wsMu.Unlock()
+					// Brief pause to let the client receive the final patches
+					time.Sleep(100 * time.Millisecond)
+				}
+			}
+			return
 		}
 	}
 }

--- a/live/jscommand.go
+++ b/live/jscommand.go
@@ -104,6 +104,11 @@ func (q *CommandQueue) Toggle(selector string) {
 	q.PushCommand("toggle", selector, nil)
 }
 
+// Navigate queues a client-side navigation to the given URL.
+func (q *CommandQueue) Navigate(url string) {
+	q.PushCommand("navigate", "", map[string]string{"url": url})
+}
+
 // DrainCommands returns all queued commands and clears the queue.
 func (q *CommandQueue) DrainCommands() []jsCommand {
 	q.mu.Lock()

--- a/live/view.go
+++ b/live/view.go
@@ -43,6 +43,19 @@ type InfoReceiver interface {
 	HandleInfo(msg any) error
 }
 
+// SessionExpiredHandler is an optional interface that Views can implement
+// to perform cleanup before the connection is closed due to session invalidation.
+// If not implemented, the connection is closed immediately.
+//
+// Typical uses include showing a toast notification, auto-saving drafts,
+// or dispatching a client-side redirect.
+type SessionExpiredHandler interface {
+	// OnSessionExpired is called when the session is invalidated
+	// (e.g. by logout or expiry). The view's state changes are rendered
+	// and sent to the client before the connection is closed.
+	OnSessionExpired() error
+}
+
 // ConnInfo holds connection-level information available at Mount time.
 type ConnInfo struct {
 	Session    *session.Session

--- a/session/broker.go
+++ b/session/broker.go
@@ -1,0 +1,69 @@
+package session
+
+import "sync"
+
+// Broker distributes session invalidation events to subscribers.
+// When a session is destroyed or expires, all subscribers for that
+// session ID are notified via their channels.
+type Broker struct {
+	mu          sync.RWMutex
+	subscribers map[string]map[uint64]chan struct{}
+	nextID      uint64
+}
+
+// NewBroker creates a new Broker.
+func NewBroker() *Broker {
+	return &Broker{
+		subscribers: make(map[string]map[uint64]chan struct{}),
+	}
+}
+
+// Subscribe registers for invalidation notifications on the given session ID.
+// Returns a channel that will be closed when the session is invalidated,
+// and an unsubscribe function that must be called when done (typically via defer).
+func (b *Broker) Subscribe(sessionID string) (ch <-chan struct{}, unsubscribe func()) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	id := b.nextID
+	b.nextID++
+
+	c := make(chan struct{}, 1)
+	if b.subscribers[sessionID] == nil {
+		b.subscribers[sessionID] = make(map[uint64]chan struct{})
+	}
+	b.subscribers[sessionID][id] = c
+
+	return c, func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		delete(b.subscribers[sessionID], id)
+		if len(b.subscribers[sessionID]) == 0 {
+			delete(b.subscribers, sessionID)
+		}
+	}
+}
+
+// Invalidate notifies all subscribers for the given session ID.
+// Each subscriber's channel receives a signal (non-blocking send).
+func (b *Broker) Invalidate(sessionID string) {
+	b.mu.RLock()
+	subs := b.subscribers[sessionID]
+	if len(subs) == 0 {
+		b.mu.RUnlock()
+		return
+	}
+	// Copy channels under read lock to avoid holding lock during sends
+	chs := make([]chan struct{}, 0, len(subs))
+	for _, ch := range subs {
+		chs = append(chs, ch)
+	}
+	b.mu.RUnlock()
+
+	for _, ch := range chs {
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+}

--- a/session/broker_test.go
+++ b/session/broker_test.go
@@ -1,0 +1,136 @@
+package session
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBroker_SubscribeAndInvalidate(t *testing.T) {
+	b := NewBroker()
+	ch, unsub := b.Subscribe("sess1")
+	defer unsub()
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		b.Invalidate("sess1")
+	}()
+
+	select {
+	case <-ch:
+		// success
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for invalidation")
+	}
+}
+
+func TestBroker_InvalidateUnknownSession(t *testing.T) {
+	b := NewBroker()
+	// Should not panic
+	b.Invalidate("nonexistent")
+}
+
+func TestBroker_MultipleSubscribers(t *testing.T) {
+	b := NewBroker()
+	ch1, unsub1 := b.Subscribe("sess1")
+	defer unsub1()
+	ch2, unsub2 := b.Subscribe("sess1")
+	defer unsub2()
+
+	b.Invalidate("sess1")
+
+	for i, ch := range []<-chan struct{}{ch1, ch2} {
+		select {
+		case <-ch:
+			// success
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d: timed out waiting for invalidation", i)
+		}
+	}
+}
+
+func TestBroker_Unsubscribe(t *testing.T) {
+	b := NewBroker()
+	ch, unsub := b.Subscribe("sess1")
+	unsub()
+
+	b.Invalidate("sess1")
+
+	select {
+	case <-ch:
+		t.Fatal("should not receive after unsubscribe")
+	case <-time.After(50 * time.Millisecond):
+		// success: no notification
+	}
+}
+
+func TestBroker_UnsubscribeCleansUp(t *testing.T) {
+	b := NewBroker()
+	_, unsub := b.Subscribe("sess1")
+	unsub()
+
+	b.mu.RLock()
+	_, exists := b.subscribers["sess1"]
+	b.mu.RUnlock()
+	if exists {
+		t.Error("subscriber map entry should be removed after last unsubscribe")
+	}
+}
+
+func TestBroker_DifferentSessions(t *testing.T) {
+	b := NewBroker()
+	ch1, unsub1 := b.Subscribe("sess1")
+	defer unsub1()
+	ch2, unsub2 := b.Subscribe("sess2")
+	defer unsub2()
+
+	b.Invalidate("sess1")
+
+	select {
+	case <-ch1:
+		// success
+	case <-time.After(time.Second):
+		t.Fatal("sess1 subscriber should have been notified")
+	}
+
+	select {
+	case <-ch2:
+		t.Fatal("sess2 subscriber should not have been notified")
+	case <-time.After(50 * time.Millisecond):
+		// success
+	}
+}
+
+func TestBroker_BufferedChannel(t *testing.T) {
+	b := NewBroker()
+	ch, unsub := b.Subscribe("sess1")
+	defer unsub()
+
+	// Multiple invalidations should not block the sender
+	b.Invalidate("sess1")
+	b.Invalidate("sess1")
+	b.Invalidate("sess1")
+
+	select {
+	case <-ch:
+		// success: received at least one
+	case <-time.After(time.Second):
+		t.Fatal("should have received notification")
+	}
+}
+
+func TestBroker_ConcurrentAccess(t *testing.T) {
+	b := NewBroker()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			_, unsub := b.Subscribe("sess1")
+			defer unsub()
+			b.Invalidate("sess1")
+		}(i)
+	}
+	wg.Wait()
+}

--- a/session/memory.go
+++ b/session/memory.go
@@ -9,6 +9,7 @@ import (
 )
 
 // MemoryStore is an in-memory session store.
+// It implements both Store and BrokerStore interfaces.
 type MemoryStore struct {
 	mu         sync.RWMutex
 	sessions   map[string]*Session
@@ -17,6 +18,7 @@ type MemoryStore struct {
 	cookie     CookieConfig
 	gcInterval time.Duration
 	stopGC     chan struct{}
+	broker     *Broker
 }
 
 // MemoryOption configures a MemoryStore.
@@ -54,6 +56,7 @@ func NewMemoryStore(key []byte, opts ...MemoryOption) *MemoryStore {
 		cookie:     defaultCookieConfig(),
 		gcInterval: 10 * time.Minute,
 		stopGC:     make(chan struct{}),
+		broker:     NewBroker(),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -107,12 +110,20 @@ func (s *MemoryStore) Save(w http.ResponseWriter, r *http.Request, sess *Session
 }
 
 // Destroy removes the session from the store and clears the cookie.
+// It also notifies all Broker subscribers for this session.
 func (s *MemoryStore) Destroy(w http.ResponseWriter, r *http.Request, sess *Session) error {
 	s.mu.Lock()
 	delete(s.sessions, sess.ID)
 	s.mu.Unlock()
+	s.broker.Invalidate(sess.ID)
 	clearCookie(w, s.cookie)
 	return nil
+}
+
+// Broker returns the session invalidation broker.
+// This satisfies the BrokerStore interface.
+func (s *MemoryStore) Broker() *Broker {
+	return s.broker
 }
 
 // Close stops the background GC goroutine.
@@ -129,16 +140,21 @@ func (s *MemoryStore) gc() {
 			return
 		case <-ticker.C:
 			now := time.Now()
+			var expired []string
 			s.mu.Lock()
 			for id, sess := range s.sessions {
 				sess.mu.RLock()
-				expired := now.After(sess.expiresAt)
+				isExpired := now.After(sess.expiresAt)
 				sess.mu.RUnlock()
-				if expired {
+				if isExpired {
 					delete(s.sessions, id)
+					expired = append(expired, id)
 				}
 			}
 			s.mu.Unlock()
+			for _, id := range expired {
+				s.broker.Invalidate(id)
+			}
 		}
 	}
 }

--- a/session/memory_test.go
+++ b/session/memory_test.go
@@ -140,3 +140,68 @@ func TestMemoryStore_GC(t *testing.T) {
 		t.Errorf("expected 0 sessions after GC, got %d", count)
 	}
 }
+
+func TestMemoryStore_ImplementsBrokerStore(t *testing.T) {
+	store := NewMemoryStore([]byte("secret"))
+	defer store.Close()
+
+	var _ BrokerStore = store
+}
+
+func TestMemoryStore_Broker(t *testing.T) {
+	store := NewMemoryStore([]byte("secret"))
+	defer store.Close()
+
+	if store.Broker() == nil {
+		t.Fatal("Broker() should not return nil")
+	}
+}
+
+func TestMemoryStore_DestroyNotifiesBroker(t *testing.T) {
+	store := NewMemoryStore([]byte("secret"))
+	defer store.Close()
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	sess, _ := store.Get(r)
+	store.Save(w, r, sess)
+
+	// Subscribe before destroy
+	ch, unsub := store.Broker().Subscribe(sess.ID)
+	defer unsub()
+
+	// Destroy should trigger notification
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest("GET", "/", nil)
+	store.Destroy(w2, r2, sess)
+
+	select {
+	case <-ch:
+		// success
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for broker notification on Destroy")
+	}
+}
+
+func TestMemoryStore_GCNotifiesBroker(t *testing.T) {
+	store := NewMemoryStore([]byte("secret"),
+		WithMaxAge(50*time.Millisecond),
+		WithGCInterval(50*time.Millisecond),
+	)
+	defer store.Close()
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	sess, _ := store.Get(r)
+	store.Save(w, r, sess)
+
+	ch, unsub := store.Broker().Subscribe(sess.ID)
+	defer unsub()
+
+	select {
+	case <-ch:
+		// success: GC triggered broker notification
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for broker notification on GC expiry")
+	}
+}

--- a/session/session.go
+++ b/session/session.go
@@ -80,3 +80,11 @@ type Store interface {
 	// Destroy removes the session from the store and clears the cookie.
 	Destroy(w http.ResponseWriter, r *http.Request, sess *Session) error
 }
+
+// BrokerStore is an optional interface that Store implementations can satisfy
+// to support push-based session invalidation. The live/ package detects this
+// via type assertion and automatically subscribes WebSocket connections.
+type BrokerStore interface {
+	Store
+	Broker() *Broker
+}


### PR DESCRIPTION
## Summary

- `session.Broker` によるPush型セッション無効化通知を実装
- `SessionExpiredHandler` コールバックインターフェースを追加し、セッション無効化時にView側でグレースフルな処理（通知表示、リダイレクト等）が可能に
- `MemoryStore` に `BrokerStore` インターフェースを統合（Destroy・GC時にBroker通知）
- `live.Handler` に `WithSessionStore` オプションを追加、WebSocket接続時に自動購読
- `Navigate` JSコマンドを追加（クライアント側リダイレクト用）
- `example/auth` をLiveViewダッシュボードに書き換え、ログアウト時の全接続切断デモを実装

## Changes

| File | Description |
|------|-------------|
| `session/broker.go` | Broker型（Subscribe/Invalidate、バッファ1チャネル、RWMutex保護） |
| `session/session.go` | BrokerStoreインターフェース追加 |
| `session/memory.go` | MemoryStoreにBroker統合（Destroy/GC時のInvalidate呼び出し） |
| `live/view.go` | SessionExpiredHandlerインターフェース定義 |
| `live/handler.go` | WithSessionStoreオプション、WebSocket接続時の自動購読 |
| `live/jscommand.go` | Navigate JSコマンド追加 |
| `live/gerbera.js` | navigateコマンドのクライアント側実装 |
| `example/auth/auth.go` | LiveViewダッシュボード + SessionExpiredHandlerデモ |
| `session/broker_test.go` | Broker単体テスト（8テスト） |
| `session/memory_test.go` | MemoryStore Broker統合テスト追加 |

## Design decisions

- `BrokerStore` はオプショナルインターフェース（type assertion）。既存のStore実装に影響なし
- `SessionExpiredHandler` もオプショナル。未実装のViewは即切断（デフォルト動作）
- nilチャネルはselectで受信しないため、BrokerStore未設定時はゼロコストで無効化通知をスキップ

## Test plan

- [x] `go build ./...` — ビルド確認
- [x] `go test ./...` — 全テスト通過
- [x] Broker単体テスト（Subscribe/Invalidate/Unsubscribe/並行アクセス）
- [x] MemoryStore Broker統合テスト（Destroy通知/GC通知）
- [x] `go run example/auth/auth.go` — 手動動作確認（2タブでログイン→片方ログアウト→他方がリダイレクト）

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)