### PR TITLE
Add multi-user chat example with LiveSession/Unmounter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,8 @@ go run example/catalog/catalog.go           # Run catalog LiveView example on :8
 go run example/catalog/catalog.go -debug    # Run catalog with debug panel enabled
 go run example/auth/auth.go                # Run auth session example on :8895
 go run example/auth/auth.go -debug         # Run auth with debug panel enabled
+go run example/chat/chat.go               # Run chat LiveView example on :8920
+go run example/chat/chat.go -debug        # Run chat with debug panel enabled
 ```
 
 External dependencies: `github.com/gorilla/websocket` (only used by `live/` package), `github.com/yuin/goldmark` (only used by `example/mdviewer`).

--- a/example/chat/chat.go
+++ b/example/chat/chat.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	g "github.com/tomo3110/gerbera"
+	gd "github.com/tomo3110/gerbera/dom"
+	"github.com/tomo3110/gerbera/expr"
+	gl "github.com/tomo3110/gerbera/live"
+	gp "github.com/tomo3110/gerbera/property"
+	gs "github.com/tomo3110/gerbera/styles"
+	gu "github.com/tomo3110/gerbera/ui"
+)
+
+// shared Hub instance
+var hub = NewHub()
+
+// ChatView implements the LiveView for a multi-user chat room.
+type ChatView struct {
+	gl.CommandQueue
+
+	Username string
+	Messages []ChatMessage
+	Draft    string
+
+	hub     *Hub
+	session *gl.Session
+}
+
+func (v *ChatView) Mount(params gl.Params) error {
+	v.hub = hub
+	v.session = params.Conn.LiveSession
+	return nil
+}
+
+func (v *ChatView) HandleEvent(event string, payload gl.Payload) error {
+	switch event {
+	case "join":
+		name := payload["username"]
+		if name == "" {
+			return nil
+		}
+		v.Username = name
+		v.hub.Join(v.session)
+		v.hub.Broadcast(ChatMessage{
+			Author:    name,
+			Content:   fmt.Sprintf("%s joined the room", name),
+			Timestamp: time.Now().Format("15:04"),
+			System:    true,
+		}, v.session.ID)
+
+	case "input":
+		v.Draft = payload["value"]
+
+	case "send":
+		if v.Draft == "" || v.Username == "" {
+			return nil
+		}
+		msg := ChatMessage{
+			Author:    v.Username,
+			Content:   v.Draft,
+			Timestamp: time.Now().Format("15:04"),
+		}
+		v.Messages = append(v.Messages, msg)
+		v.Draft = ""
+		v.hub.Broadcast(msg, v.session.ID)
+		v.ScrollIntoPct("#chat-messages", "1.0")
+
+	case "keydown":
+		if payload["key"] != "Enter" {
+			return nil
+		}
+		if v.Draft == "" || v.Username == "" {
+			return nil
+		}
+		msg := ChatMessage{
+			Author:    v.Username,
+			Content:   v.Draft,
+			Timestamp: time.Now().Format("15:04"),
+		}
+		v.Messages = append(v.Messages, msg)
+		v.Draft = ""
+		v.hub.Broadcast(msg, v.session.ID)
+		v.ScrollIntoPct("#chat-messages", "1.0")
+	}
+	return nil
+}
+
+// HandleInfo receives ChatMessages broadcast from other users via the Hub.
+func (v *ChatView) HandleInfo(msg any) error {
+	if cm, ok := msg.(ChatMessage); ok {
+		v.Messages = append(v.Messages, cm)
+		v.ScrollIntoPct("#chat-messages", "1.0")
+	}
+	return nil
+}
+
+// Unmount is called when the WebSocket connection closes.
+func (v *ChatView) Unmount() {
+	if v.Username != "" && v.session != nil {
+		v.hub.Leave(v.session.ID)
+		v.hub.Broadcast(ChatMessage{
+			Author:    v.Username,
+			Content:   fmt.Sprintf("%s left the room", v.Username),
+			Timestamp: time.Now().Format("15:04"),
+			System:    true,
+		}, v.session.ID)
+	}
+}
+
+func (v *ChatView) Render() []g.ComponentFunc {
+	return []g.ComponentFunc{
+		gd.Head(
+			gd.Title("Chat — Gerbera LiveView"),
+			gd.Meta(gp.Attr("name", "viewport"), gp.Attr("content", "width=device-width, initial-scale=1")),
+			gu.Theme(),
+			gs.CSS(pageCSS),
+		),
+		gd.Body(
+			gu.Container(
+				gu.Stack(
+					// Header
+					gd.Div(
+						gp.Class("chat-header"),
+						gd.H1(gp.Value("Chat Room")),
+						gu.Badge(fmt.Sprintf("Online: %d", v.hub.OnlineCount())),
+					),
+
+					// Main content
+					expr.If(v.Username == "", v.renderJoinForm()),
+					expr.If(v.Username != "", v.renderChat()),
+				),
+			),
+		),
+	}
+}
+
+func (v *ChatView) renderJoinForm() g.ComponentFunc {
+	return gu.Card(
+		gu.CardHeader("Join Chat"),
+		gu.CardBody(
+			gd.Form(
+				gl.Submit("join"),
+				gu.Stack(
+					gu.FormGroup(
+						gu.FormLabel("Username", "username"),
+						gu.FormInput("username",
+							gp.ID("username"),
+							gp.Placeholder("Enter your name"),
+							gp.Attr("required", "required"),
+						),
+					),
+					gu.Button("Join", gu.ButtonPrimary),
+				),
+			),
+		),
+	)
+}
+
+func (v *ChatView) renderChat() g.ComponentFunc {
+	var msgViews []g.ComponentFunc
+	msgViews = append(msgViews, gp.ID("chat-messages"))
+	for _, m := range v.Messages {
+		msg := m // capture
+		if msg.System {
+			msgViews = append(msgViews, gd.Div(
+				gp.Class("chat-system-msg"),
+				gp.Value(msg.Content),
+			))
+		} else {
+			msgViews = append(msgViews, gu.ChatMessageView(gu.ChatMessage{
+				Author:    msg.Author,
+				Content:   msg.Content,
+				Timestamp: msg.Timestamp,
+				Sent:      msg.Author == v.Username,
+				Avatar:    string([]rune(msg.Author)[0]),
+			}))
+		}
+	}
+
+	return gu.Card(
+		gu.CardBody(
+			gu.ChatContainer(msgViews...),
+		),
+		gu.CardFooter(
+			gu.ChatInput("draft", v.Draft, gu.ChatInputOpts{
+				Placeholder:  "Type a message...",
+				SendEvent:    "send",
+				InputEvent:   "input",
+				KeydownEvent: "keydown",
+			}),
+		),
+	)
+}
+
+const pageCSS = `
+body {
+	background: var(--g-bg);
+	color: var(--g-text);
+	font-family: var(--g-font);
+	margin: 0;
+	padding: var(--g-space-md) 0;
+}
+.chat-header {
+	display: flex;
+	align-items: center;
+	gap: var(--g-space-sm);
+}
+.chat-header h1 {
+	margin: 0;
+	font-size: 1.4rem;
+	flex: 1;
+}
+.g-chat {
+	min-height: 300px;
+	max-height: 60vh;
+}
+.chat-system-msg {
+	text-align: center;
+	color: var(--g-text-tertiary);
+	font-size: 0.85rem;
+	padding: var(--g-space-xs) 0;
+}
+`
+
+func main() {
+	debug := flag.Bool("debug", false, "enable debug panel")
+	flag.Parse()
+
+	var opts []gl.Option
+	if *debug {
+		opts = append(opts, gl.WithDebug())
+	}
+
+	http.Handle("/", gl.Handler(func(_ context.Context) gl.View {
+		return &ChatView{}
+	}, opts...))
+
+	log.Println("Chat running on http://localhost:8920")
+	log.Fatal(http.ListenAndServe(":8920", nil))
+}

--- a/example/chat/hub.go
+++ b/example/chat/hub.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"sync"
+
+	"github.com/tomo3110/gerbera/live"
+)
+
+// ChatMessage represents a single chat message exchanged via the Hub.
+type ChatMessage struct {
+	Author    string
+	Content   string
+	Timestamp string
+	System    bool // system messages (join/leave notifications)
+}
+
+// Hub is a simple pub/sub that broadcasts ChatMessages to connected LiveView sessions.
+type Hub struct {
+	mu      sync.RWMutex
+	clients map[string]*live.Session
+}
+
+// NewHub creates an empty Hub.
+func NewHub() *Hub {
+	return &Hub{
+		clients: make(map[string]*live.Session),
+	}
+}
+
+// Join registers a LiveView session with the Hub.
+func (h *Hub) Join(sess *live.Session) {
+	h.mu.Lock()
+	h.clients[sess.ID] = sess
+	h.mu.Unlock()
+}
+
+// Leave removes a LiveView session from the Hub.
+func (h *Hub) Leave(sessionID string) {
+	h.mu.Lock()
+	delete(h.clients, sessionID)
+	h.mu.Unlock()
+}
+
+// OnlineCount returns the number of connected clients.
+func (h *Hub) OnlineCount() int {
+	h.mu.RLock()
+	n := len(h.clients)
+	h.mu.RUnlock()
+	return n
+}
+
+// Broadcast sends a ChatMessage to all connected sessions except the sender.
+func (h *Hub) Broadcast(msg ChatMessage, senderID string) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for id, sess := range h.clients {
+		if id == senderID {
+			continue
+		}
+		sess.SendInfo(msg)
+	}
+}

--- a/live/handler.go
+++ b/live/handler.go
@@ -135,23 +135,25 @@ func Handler(viewFactory func(context.Context) View, opts ...Option) http.Handle
 func handleHTTP(w http.ResponseWriter, r *http.Request, viewFactory func(context.Context) View, store *sessionStore, cfg *handlerConfig, dlog *debugLogger) {
 	view := viewFactory(r.Context())
 
+	sess := store.create(view)
+	dlog.sessionCreated(sess.ID)
+
 	params := Params{
 		Query: r.URL.Query(),
 		Conn: ConnInfo{
-			RemoteAddr: r.RemoteAddr,
-			UserAgent:  r.Header.Get("User-Agent"),
+			LiveSession: sess,
+			RemoteAddr:  r.RemoteAddr,
+			UserAgent:   r.Header.Get("User-Agent"),
 		},
 	}
-	if sess := session.FromContext(r.Context()); sess != nil {
-		params.Conn.Session = sess
+	if httpSess := session.FromContext(r.Context()); httpSess != nil {
+		params.Conn.Session = httpSess
 	}
 	if err := view.Mount(params); err != nil {
+		store.remove(sess.ID)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-
-	sess := store.create(view)
-	dlog.sessionCreated(sess.ID)
 
 	components := view.Render()
 	if cfg.debug {

--- a/live/loop.go
+++ b/live/loop.go
@@ -25,6 +25,13 @@ type ViewLoopConfig struct {
 // It blocks until the Transport is closed, the session is invalidated,
 // or an unrecoverable send error occurs.
 func ViewLoop(view View, transport Transport, cfg ViewLoopConfig) error {
+	// --- unmount cleanup ---
+	defer func() {
+		if u, ok := view.(Unmounter); ok {
+			u.Unmount()
+		}
+	}()
+
 	// --- event receive goroutine ---
 	type eventMsg struct {
 		name    string

--- a/live/loop_test.go
+++ b/live/loop_test.go
@@ -57,6 +57,13 @@ func (v *loopSessionExpiredView) OnSessionExpired() error {
 	return nil
 }
 
+type loopUnmountView struct {
+	loopTestView
+	Unmounted bool
+}
+
+func (v *loopUnmountView) Unmount() { v.Unmounted = true }
+
 // --- tests ---
 
 func TestViewLoopBasicEvent(t *testing.T) {
@@ -244,5 +251,29 @@ func TestViewLoopCloseReturnsNil(t *testing.T) {
 
 	if loopErr != nil {
 		t.Errorf("expected nil on clean close, got %v", loopErr)
+	}
+}
+
+func TestViewLoopUnmount(t *testing.T) {
+	view := &loopUnmountView{}
+	view.Mount(Params{})
+
+	tr := NewTestTransport()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ViewLoop(view, tr, ViewLoopConfig{
+			SessionID: "test-sess",
+			Lang:      "en",
+		})
+	}()
+
+	tr.Close()
+	wg.Wait()
+
+	if !view.Unmounted {
+		t.Error("expected Unmount() to be called on ViewLoop exit")
 	}
 }

--- a/live/view.go
+++ b/live/view.go
@@ -56,11 +56,19 @@ type SessionExpiredHandler interface {
 	OnSessionExpired() error
 }
 
+// Unmounter is an optional interface that Views can implement
+// to perform cleanup when the WebSocket connection is closed.
+// Unmount is called automatically at the end of ViewLoop.
+type Unmounter interface {
+	Unmount()
+}
+
 // ConnInfo holds connection-level information available at Mount time.
 type ConnInfo struct {
-	Session    *session.Session
-	RemoteAddr string
-	UserAgent  string
+	Session     *session.Session
+	LiveSession *Session // LiveView session (for SendInfo)
+	RemoteAddr  string
+	UserAgent   string
 }
 
 // Params holds URL query parameters and connection info passed to Mount.


### PR DESCRIPTION
## Summary
- `live/view.go`: `ConnInfo` に `LiveSession *Session` フィールドを追加し、View から `SendInfo` を呼べるようにした。接続終了時クリーンアップ用の `Unmounter` インターフェースを追加
- `live/handler.go`: `handleHTTP` でセッション作成を `Mount` 前に移動し、`LiveSession` を `Params` 経由で渡す。Mount 失敗時のセッションリーク防止も追加
- `live/loop.go`: `ViewLoop` 終了時に `Unmounter.Unmount()` を自動呼び出しする defer を追加
- `live/loop_test.go`: `TestViewLoopUnmount` テストを追加
- `example/chat/`: Hub pub/sub + `ChatView` によるマルチユーザーリアルタイムチャットサンプル（`:8920`）

Closes #22

## Test plan
- [x] `go build ./...` — 全パッケージビルド成功
- [x] `go test ./...` — 全テスト通過（`TestViewLoopUnmount` 含む）
- [x] `go run example/chat/chat.go` でチャット起動 → ブラウザ複数タブで `http://localhost:8920` を開きリアルタイムチャット動作確認
- [x] 半角文字（ASCII）のみのメッセージが送信できることを確認
- [x] タブを閉じた際に退出メッセージが他ユーザーに配信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)