### PR TITLE
Update documentation for session, advanced LiveView interfaces, and new examples

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -130,9 +130,10 @@ gerbera/
 ├── property/          # 属性セッター (Class, Attr, ID, ARIA ヘルパーなど)
 ├── expr/              # 制御フロー: If()、Unless()、Each()
 ├── styles/            # Style(), CSS(), ScopedCSS() による CSS 処理
-├── components/        # ビルド済みコンポーネント (Bootstrap CDN, Tabs など)
+├── components/        # ビルド済みコンポーネント (Bootstrap CDN, TailwindCSS, Tabs など)
 ├── diff/              # 要素ツリー差分比較とフラグメントレンダリング
 ├── live/              # LiveView: View インターフェース、WebSocket ハンドラ、クライアント JS
+├── session/           # HTTP セッション管理 (MemoryStore, CSRF, ミドルウェア)
 ├── ui/               # テーマシステム付きビルド済み UI コンポーネントライブラリ
 │   └── live/         # LiveView 専用コンポーネント (Modal, Toast, DataTable 等)
 │
@@ -151,7 +152,9 @@ gerbera/
     ├── wiki_live/     # LiveView Wiki (SPA 風)
     ├── mdviewer/      # LiveView Markdown ビューアー/エディタ
     ├── admin/         # LiveView 管理画面ダッシュボード
-    └── catalog/       # インタラクティブ UI コンポーネントカタログ
+    ├── catalog/       # インタラクティブ UI コンポーネントカタログ
+    ├── auth/          # CSRF 付きセッション認証
+    └── chat/          # マルチユーザーリアルタイムチャット (InfoReceiver)
 ```
 
 ### コアコンセプト
@@ -166,6 +169,23 @@ type ComponentFunc func(*Element) error
 
 ```go
 gd.Div(children...)  // g.Tag("div", children...) と同等
+```
+
+**Skip()** — 何もレンダリングしない no-op の `ComponentFunc` を返します。プレースホルダーやデフォルト値として便利です:
+
+```go
+g.Skip()  // 何もレンダリングしない
+```
+
+**HandlerFunc()** — リクエストに基づいて動的にページを生成する `http.HandlerFunc` を作成します:
+
+```go
+http.HandleFunc("/", g.HandlerFunc(func(r *http.Request) []g.ComponentFunc {
+    return []g.ComponentFunc{
+        gd.Head(gd.Title("動的ページ")),
+        gd.Body(gd.H1(gp.Value("こんにちは、" + r.URL.Query().Get("name")))),
+    }
+}))
 ```
 
 **関数合成** — コンポーネントは可変長引数 `children ...ComponentFunc` で合成します:
@@ -245,7 +265,7 @@ func (v *MyView) HandleEvent(event string, payload gl.Payload) error {
 }
 ```
 
-利用可能なコマンド: `ScrollTo`, `ScrollIntoPct`, `Focus`, `Blur`, `SetAttribute`, `RemoveAttribute`, `AddClass`, `RemoveClass`, `ToggleClass`, `SetProperty`, `Dispatch`, `Show`, `Hide`, `Toggle`
+利用可能なコマンド: `ScrollTo`, `ScrollIntoPct`, `Focus`, `Blur`, `SetAttribute`, `RemoveAttribute`, `AddClass`, `RemoveClass`, `ToggleClass`, `SetProperty`, `Dispatch`, `Show`, `Hide`, `Toggle`, `Navigate`
 
 ### アップロードサポート
 
@@ -280,6 +300,120 @@ gl.SelectField("role", []gl.SelectOption{
     {Value: "admin", Label: "管理者"},
     {Value: "user", Label: "ユーザー"},
 }, gl.FieldOpts{Label: "役割"})
+```
+
+### セッション管理（`session/` パッケージ）
+
+`session/` パッケージは HMAC-SHA256 署名付きクッキーによる HTTP セッション管理を提供します:
+
+```go
+import "github.com/tomo3110/gerbera/session"
+
+// 署名キーを指定してストアを作成
+store := session.NewMemoryStore([]byte("secret-key"),
+    session.WithMaxAge(30 * time.Minute),
+)
+defer store.Close()
+
+// セッションミドルウェアを適用してセッションを自動的に読み込み/保存
+handler := session.Middleware(store)(mux)
+```
+
+**CSRF 保護:**
+
+```go
+sess := session.FromContext(r.Context())
+token := session.GenerateCSRFToken(sess)  // トークンを生成しセッションに保存
+// ... フォームの hidden フィールドにトークンを含める ...
+valid := session.ValidCSRFToken(sess, submittedToken)  // 定数時間比較
+```
+
+**認証ガードミドルウェア:**
+
+```go
+// セッションに "username" キーがない場合は /login にリダイレクト
+authGuard := session.RequireKey("username", "/login")
+mux.Handle("/dashboard", authGuard(dashboardHandler))
+```
+
+**プッシュベースのセッション無効化:**
+
+`MemoryStore` を `gl.WithSessionStore(store)` と組み合わせると、LiveView 接続はセッション無効化イベントを自動購読します。セッション破棄（例: ログアウト時）により、関連するすべての WebSocket 接続が閉じられます。`SessionExpiredHandler` を実装した View は切断前にコールバックを受け取ります。
+
+### LiveView 上級インターフェース
+
+コアの `View` インターフェースに加えて、高度なシナリオ用のオプショナルインターフェースを提供します:
+
+**InfoReceiver** — `Session.SendInfo()` 経由でプッシュされたサーバーサイドメッセージを受信します。ユーザー間の更新ブロードキャストに便利です:
+
+```go
+type InfoReceiver interface {
+    View
+    HandleInfo(msg any) error
+}
+```
+
+```go
+func (v *ChatView) HandleInfo(msg any) error {
+    if cm, ok := msg.(ChatMessage); ok {
+        v.Messages = append(v.Messages, cm)
+    }
+    return nil
+}
+
+// 別のゴルーチンや別ユーザーのセッションから送信:
+session.SendInfo(chatMessage)
+```
+
+**Unmounter** — WebSocket 接続が閉じられた時に呼ばれます。チャットルームからの退出などのクリーンアップに使用します:
+
+```go
+type Unmounter interface {
+    Unmount()
+}
+```
+
+**SessionExpiredHandler** — HTTP セッションが無効化された時（例: 別タブからのログアウト）に呼ばれます。切断前に最終状態をレンダリングできます:
+
+```go
+type SessionExpiredHandler interface {
+    OnSessionExpired() error
+}
+```
+
+```go
+func (v *DashboardView) OnSessionExpired() error {
+    v.SessionExpired = true
+    v.Navigate("/login")  // クライアントをリダイレクト
+    return nil
+}
+```
+
+### Transport インターフェース
+
+`Transport` インターフェースは View のライフサイクルを WebSocket 接続から分離し、カスタムトランスポートやテストを容易にします:
+
+```go
+type Transport interface {
+    Send(msg Message) error
+    Receive() (event string, payload Payload, err error)
+    Close() error
+}
+```
+
+`ViewLoop()` は任意の `Transport` 実装上で View を駆動します:
+
+```go
+gl.ViewLoop(view, transport, gl.ViewLoopConfig{...})
+```
+
+**TestTransport** — WebSocket なしで LiveView をテストするためのインメモリトランスポート:
+
+```go
+transport := gl.NewTestTransport()
+go gl.ViewLoop(view, transport, cfg)
+transport.PushEvent("inc", gl.Payload{})
+msg := transport.LastMessage()
 ```
 
 ### LiveView のテスト
@@ -337,6 +471,8 @@ ARIA アクセシビリティヘルパー:
 | `gs.CSS(cssText)` | 生 CSS を含む `<style>` 要素 |
 | `gs.ScopedCSS(scope, rules)` | セレクタにスコープされた CSS ルール |
 | `gs.StyleIf(cond, styleMap)` | 条件付きインラインスタイル |
+| `gs.MediaQuery(query, css)` | CSS を `@media` ルールでラップ |
+| `gs.Keyframes(name, frames)` | `@keyframes` ルールを生成 |
 
 ### 追加 DOM 要素
 
@@ -352,6 +488,8 @@ ARIA アクセシビリティヘルパー:
 | `gl.WithSessionTTL(d)` | セッションタイムアウトを設定（デフォルト 5 分） |
 | `gl.WithDebug()` | ブラウザ DevPanel とサーバーサイド構造化ログを有効化 |
 | `gl.WithMiddleware(mw)` | HTTP ミドルウェアをハンドラに追加 |
+| `gl.WithCheckOrigin(fn)` | WebSocket アップグレード用のカスタム Origin ヘッダーチェックを設定 |
+| `gl.WithSessionStore(store)` | `session.Store` によるプッシュベースのセッション無効化を有効化 |
 
 ### デバッグモード
 
@@ -439,6 +577,8 @@ gu.Calendar(gu.CalendarOpts{Year: v.CalYear, Month: v.CalMonth, SelectEvent: "ca
 | [mdviewer](example/mdviewer/) | LiveView Markdown ビューアー | :8860 | `cd example/mdviewer && go run .` |
 | [admin](example/admin/) | LiveView 管理画面ダッシュボード | :8910 | `go run example/admin/admin.go` |
 | [catalog](example/catalog/) | インタラクティブ UI コンポーネントカタログ | :8900 | `go run example/catalog/catalog.go` |
+| [auth](example/auth/) | CSRF 付きセッション認証 | :8895 | `go run example/auth/auth.go` |
+| [chat](example/chat/) | マルチユーザーリアルタイムチャット | :8920 | `go run example/chat/chat.go` |
 
 ## 開発
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ gerbera/
 ├── property/          # Attribute setters (Class, Attr, ID, ARIA helpers, etc.)
 ├── expr/              # Control flow: If(), Unless(), Each()
 ├── styles/            # Style(), CSS(), ScopedCSS() for CSS handling
-├── components/        # Pre-built components (Bootstrap CDN, Tabs, etc.)
+├── components/        # Pre-built components (Bootstrap CDN, TailwindCSS, Tabs, etc.)
 ├── diff/              # Element tree diffing and fragment rendering
 ├── live/              # LiveView: View interface, WebSocket handler, client JS
+├── session/           # HTTP session management (MemoryStore, CSRF, middleware)
 ├── ui/               # Pre-built UI component library with theme system
 │   └── live/         # LiveView-only components (Modal, Toast, DataTable, etc.)
 │
@@ -151,7 +152,9 @@ gerbera/
     ├── wiki_live/     # LiveView Wiki (SPA-style)
     ├── mdviewer/      # LiveView Markdown viewer/editor
     ├── admin/         # LiveView admin dashboard
-    └── catalog/       # Interactive UI component catalog
+    ├── catalog/       # Interactive UI component catalog
+    ├── auth/          # Session-based authentication with CSRF
+    └── chat/          # Multi-user real-time chat (InfoReceiver)
 ```
 
 ### Core Concepts
@@ -166,6 +169,23 @@ type ComponentFunc func(*Element) error
 
 ```go
 gd.Div(children...)  // equivalent to g.Tag("div", children...)
+```
+
+**Skip()** — Returns a no-op `ComponentFunc` that renders nothing. Useful as a placeholder or default:
+
+```go
+g.Skip()  // renders nothing
+```
+
+**HandlerFunc()** — Creates an `http.HandlerFunc` that generates pages dynamically based on the request:
+
+```go
+http.HandleFunc("/", g.HandlerFunc(func(r *http.Request) []g.ComponentFunc {
+    return []g.ComponentFunc{
+        gd.Head(gd.Title("Dynamic Page")),
+        gd.Body(gd.H1(gp.Value("Hello, " + r.URL.Query().Get("name")))),
+    }
+}))
 ```
 
 **Functional composition** — Components compose via variadic `children ...ComponentFunc` parameters:
@@ -245,7 +265,7 @@ func (v *MyView) HandleEvent(event string, payload gl.Payload) error {
 }
 ```
 
-Available commands: `ScrollTo`, `ScrollIntoPct`, `Focus`, `Blur`, `SetAttribute`, `RemoveAttribute`, `AddClass`, `RemoveClass`, `ToggleClass`, `SetProperty`, `Dispatch`, `Show`, `Hide`, `Toggle`.
+Available commands: `ScrollTo`, `ScrollIntoPct`, `Focus`, `Blur`, `SetAttribute`, `RemoveAttribute`, `AddClass`, `RemoveClass`, `ToggleClass`, `SetProperty`, `Dispatch`, `Show`, `Hide`, `Toggle`, `Navigate`.
 
 ### Upload Support
 
@@ -280,6 +300,120 @@ gl.SelectField("role", []gl.SelectOption{
     {Value: "admin", Label: "Admin"},
     {Value: "user", Label: "User"},
 }, gl.FieldOpts{Label: "Role"})
+```
+
+### Session Management (`session/` package)
+
+The `session/` package provides HTTP session management with HMAC-SHA256 signed cookies:
+
+```go
+import "github.com/tomo3110/gerbera/session"
+
+// Create a store with a signing key
+store := session.NewMemoryStore([]byte("secret-key"),
+    session.WithMaxAge(30 * time.Minute),
+)
+defer store.Close()
+
+// Apply session middleware to load/save sessions automatically
+handler := session.Middleware(store)(mux)
+```
+
+**CSRF Protection:**
+
+```go
+sess := session.FromContext(r.Context())
+token := session.GenerateCSRFToken(sess)  // generate and store in session
+// ... include token in form as hidden field ...
+valid := session.ValidCSRFToken(sess, submittedToken)  // constant-time comparison
+```
+
+**Auth Guard Middleware:**
+
+```go
+// Redirect to /login if session has no "username" key
+authGuard := session.RequireKey("username", "/login")
+mux.Handle("/dashboard", authGuard(dashboardHandler))
+```
+
+**Push-based Session Invalidation:**
+
+When `MemoryStore` is used with `gl.WithSessionStore(store)`, LiveView connections automatically subscribe to session invalidation events. Destroying a session (e.g., on logout) closes all associated WebSocket connections. Views implementing `SessionExpiredHandler` receive a callback before disconnection.
+
+### LiveView Advanced Interfaces
+
+Beyond the core `View` interface, Gerbera provides optional interfaces for advanced scenarios:
+
+**InfoReceiver** — Receive server-side messages pushed via `Session.SendInfo()`. Useful for broadcasting updates between users:
+
+```go
+type InfoReceiver interface {
+    View
+    HandleInfo(msg any) error
+}
+```
+
+```go
+func (v *ChatView) HandleInfo(msg any) error {
+    if cm, ok := msg.(ChatMessage); ok {
+        v.Messages = append(v.Messages, cm)
+    }
+    return nil
+}
+
+// Send from another goroutine or another user's session:
+session.SendInfo(chatMessage)
+```
+
+**Unmounter** — Called when the WebSocket connection closes. Use for cleanup like leaving a chat room:
+
+```go
+type Unmounter interface {
+    Unmount()
+}
+```
+
+**SessionExpiredHandler** — Called when the HTTP session is invalidated (e.g., logout from another tab). The view can render a final state before disconnection:
+
+```go
+type SessionExpiredHandler interface {
+    OnSessionExpired() error
+}
+```
+
+```go
+func (v *DashboardView) OnSessionExpired() error {
+    v.SessionExpired = true
+    v.Navigate("/login")  // redirect the client
+    return nil
+}
+```
+
+### Transport Interface
+
+The `Transport` interface decouples the View lifecycle from the WebSocket connection, enabling custom transports and easier testing:
+
+```go
+type Transport interface {
+    Send(msg Message) error
+    Receive() (event string, payload Payload, err error)
+    Close() error
+}
+```
+
+`ViewLoop()` drives a View over any `Transport` implementation:
+
+```go
+gl.ViewLoop(view, transport, gl.ViewLoopConfig{...})
+```
+
+**TestTransport** — An in-memory transport for testing LiveViews without a WebSocket:
+
+```go
+transport := gl.NewTestTransport()
+go gl.ViewLoop(view, transport, cfg)
+transport.PushEvent("inc", gl.Payload{})
+msg := transport.LastMessage()
 ```
 
 ### Testing LiveViews
@@ -337,6 +471,8 @@ The `styles/` package provides additional CSS utilities:
 | `gs.CSS(cssText)` | `<style>` element with raw CSS |
 | `gs.ScopedCSS(scope, rules)` | CSS rules scoped to a selector |
 | `gs.StyleIf(cond, styleMap)` | Conditional inline styles |
+| `gs.MediaQuery(query, css)` | Wraps CSS in a `@media` rule |
+| `gs.Keyframes(name, frames)` | Generates a `@keyframes` rule |
 
 ### Additional DOM Elements
 
@@ -352,6 +488,8 @@ Handler options:
 | `gl.WithSessionTTL(d)` | Sets session timeout (default 5 minutes) |
 | `gl.WithDebug()` | Enables browser DevPanel and server-side structured logging |
 | `gl.WithMiddleware(mw)` | Adds HTTP middleware to the handler |
+| `gl.WithCheckOrigin(fn)` | Sets a custom Origin header check for WebSocket upgrades |
+| `gl.WithSessionStore(store)` | Enables push-based session invalidation via `session.Store` |
 
 ### Debug Mode
 
@@ -439,6 +577,8 @@ Each example includes bilingual tutorials (`TUTORIAL.md` / `TUTORIAL.ja.md`).
 | [mdviewer](example/mdviewer/) | LiveView Markdown Viewer | :8860 | `cd example/mdviewer && go run .` |
 | [admin](example/admin/) | LiveView admin dashboard | :8910 | `go run example/admin/admin.go` |
 | [catalog](example/catalog/) | Interactive UI component catalog | :8900 | `go run example/catalog/catalog.go` |
+| [auth](example/auth/) | Session auth with CSRF | :8895 | `go run example/auth/auth.go` |
+| [chat](example/chat/) | Multi-user real-time chat | :8920 | `go run example/chat/chat.go` |
 
 ## Development
 

--- a/example/auth/TUTORIAL.ja.md
+++ b/example/auth/TUTORIAL.ja.md
@@ -1,0 +1,114 @@
+# Auth サンプルチュートリアル
+
+このサンプルは `session/` パッケージを使用したセッションベースの認証を実演します。CSRF 保護、セッションミドルウェア、プッシュベースのセッション無効化を含みます。
+
+## 概要
+
+auth サンプルが実装する機能:
+
+- CSRF トークン保護付き**ログインフォーム**（サーバーサイドレンダリング）
+- `session.RequireKey` ミドルウェアで保護された **LiveView ダッシュボード**
+- **セッション無効化** — あるタブでログアウトすると `SessionExpiredHandler` 経由で他のすべてのタブが自動的にリダイレクト
+
+## 主要コンセプト
+
+### MemoryStore
+
+`session.MemoryStore` はセッションデータをメモリに保持し、HMAC-SHA256 署名付きクッキーを使用します。クッキーにはセッション ID のみが含まれ、すべてのデータはサーバー側に保持されます。
+
+```go
+key := []byte("example-secret-key-change-in-prod")
+store := session.NewMemoryStore(key)
+defer store.Close()  // バックグラウンド GC ゴルーチンを停止
+```
+
+オプションには `WithMaxAge(duration)`、`WithCookie(config)`、`WithGCInterval(duration)` があります。
+
+### セッションミドルウェア
+
+`session.Middleware` は HTTP ハンドラをラップし、各リクエストでクッキーからセッションを自動的に読み込み、ハンドラの処理後に保存します:
+
+```go
+sessionMW := session.Middleware(store)
+handler := sessionMW(mux)
+```
+
+セッションは `session.FromContext(r.Context())` で取得できます。
+
+### CSRF 保護
+
+`session/` パッケージは定数時間比較を使用した CSRF トークンヘルパーを提供します:
+
+```go
+sess := session.FromContext(r.Context())
+token := session.GenerateCSRFToken(sess)  // トークンを生成しセッションに保存
+// hidden フォームフィールドにトークンを含める:
+// <input type="hidden" name="csrf_token" value="...">
+
+// フォーム送信時にバリデーション:
+if !session.ValidCSRFToken(sess, r.FormValue("csrf_token")) {
+    http.Error(w, "invalid CSRF token", http.StatusForbidden)
+    return
+}
+```
+
+### RequireKey 認証ガード
+
+`session.RequireKey` は未認証ユーザーをリダイレクトするミドルウェアを作成します:
+
+```go
+authGuard := session.RequireKey("username", "/login")
+mux.Handle("/", authGuard(protectedHandler))
+```
+
+セッションに `"username"` キーがない場合、ユーザーは `/login` にリダイレクトされます。
+
+### プッシュベースのセッション無効化
+
+`gl.WithSessionStore(store)` を LiveView ハンドラに渡すと、WebSocket 接続はストアの `Broker` 経由でセッション無効化イベントを購読します。セッション破棄（例: ログアウト時）により、購読中のすべての接続に通知されます。
+
+`SessionExpiredHandler` を実装した View はコールバックを受け取ります:
+
+```go
+func (v *DashboardView) OnSessionExpired() error {
+    v.SessionExpired = true
+    v.Navigate("/login")
+    return nil
+}
+```
+
+これによりリアルタイムのクロスタブログアウトが実現します: あるブラウザタブでログアウトすると、ダッシュボードを表示している他のすべてのタブがリダイレクトされます。
+
+## ウォークスルー
+
+### main()
+
+1. 署名キーを指定して `MemoryStore` を作成
+2. セッションの自動読み込み/保存のために `session.Middleware` を設定
+3. 認証ガードとして `session.RequireKey("username", "/login")` を設定
+4. ルートを登録:
+   - `GET /login` — ログインフォームを表示（ログイン済みの場合は `/` にリダイレクト）
+   - `POST /login` — 資格情報と CSRF トークンを検証
+   - `/logout` — セッションを破棄し `/login` にリダイレクト
+   - `/` — `WithSessionStore` 付きの保護された LiveView ダッシュボード
+
+### ログインフロー
+
+1. ユーザーが `/login` にアクセス → `loginFormPage()` が CSRF トークン付きフォームを表示
+2. ユーザーが資格情報を送信 → `loginPostHandler()` が CSRF トークンとパスワードを検証
+3. 成功時、`sess.Set("username", username)` でセッションにユーザーを保存
+4. ユーザーは `/` にリダイレクトされ `DashboardView` が表示される
+
+### DashboardView
+
+- `Mount()` が `params.Conn.Session.GetString("username")` を読み取ってユーザー名を表示
+- `OnSessionExpired()` が警告フラグを設定し `v.Navigate("/login")` でリダイレクト
+
+## 実行方法
+
+```bash
+go run example/auth/auth.go          # http://localhost:8895
+go run example/auth/auth.go -debug   # デバッグパネル付き
+```
+
+任意のユーザー名とパスワード `"password"` でログインできます。複数タブを開いてクロスタブセッション無効化をテストしてください。

--- a/example/auth/TUTORIAL.md
+++ b/example/auth/TUTORIAL.md
@@ -1,0 +1,114 @@
+# Auth Example Tutorial
+
+This example demonstrates session-based authentication using the `session/` package with CSRF protection, session middleware, and push-based session invalidation.
+
+## Overview
+
+The auth example implements:
+
+- **Login form** with CSRF token protection (server-side rendered)
+- **Protected dashboard** as a LiveView, guarded by `session.RequireKey` middleware
+- **Session invalidation** — logging out in one tab automatically redirects all other tabs via `SessionExpiredHandler`
+
+## Key Concepts
+
+### MemoryStore
+
+`session.MemoryStore` stores session data in memory with HMAC-SHA256 signed cookies. The cookie only contains the session ID — all data stays on the server.
+
+```go
+key := []byte("example-secret-key-change-in-prod")
+store := session.NewMemoryStore(key)
+defer store.Close()  // stops background GC goroutine
+```
+
+Options include `WithMaxAge(duration)`, `WithCookie(config)`, and `WithGCInterval(duration)`.
+
+### Session Middleware
+
+`session.Middleware` wraps an HTTP handler to automatically load the session from the cookie on each request and save it after the handler returns:
+
+```go
+sessionMW := session.Middleware(store)
+handler := sessionMW(mux)
+```
+
+The session is then available via `session.FromContext(r.Context())`.
+
+### CSRF Protection
+
+The `session/` package provides CSRF token helpers using constant-time comparison:
+
+```go
+sess := session.FromContext(r.Context())
+token := session.GenerateCSRFToken(sess)  // create token, store in session
+// Include token in a hidden form field:
+// <input type="hidden" name="csrf_token" value="...">
+
+// On form submission, validate:
+if !session.ValidCSRFToken(sess, r.FormValue("csrf_token")) {
+    http.Error(w, "invalid CSRF token", http.StatusForbidden)
+    return
+}
+```
+
+### RequireKey Auth Guard
+
+`session.RequireKey` creates middleware that redirects unauthenticated users:
+
+```go
+authGuard := session.RequireKey("username", "/login")
+mux.Handle("/", authGuard(protectedHandler))
+```
+
+If the session does not contain a `"username"` key, the user is redirected to `/login`.
+
+### Push-based Session Invalidation
+
+When `gl.WithSessionStore(store)` is passed to the LiveView handler, WebSocket connections subscribe to session invalidation events via the store's `Broker`. Destroying a session (e.g., on logout) notifies all subscribed connections.
+
+Views implementing `SessionExpiredHandler` receive a callback:
+
+```go
+func (v *DashboardView) OnSessionExpired() error {
+    v.SessionExpired = true
+    v.Navigate("/login")
+    return nil
+}
+```
+
+This enables real-time cross-tab logout: logging out in one browser tab redirects all other tabs showing the dashboard.
+
+## Walkthrough
+
+### main()
+
+1. Creates a `MemoryStore` with a signing key
+2. Sets up `session.Middleware` for automatic session loading/saving
+3. Sets up `session.RequireKey("username", "/login")` as an auth guard
+4. Registers routes:
+   - `GET /login` — renders the login form (redirects to `/` if already logged in)
+   - `POST /login` — validates credentials and CSRF token
+   - `/logout` — destroys session and redirects to `/login`
+   - `/` — protected LiveView dashboard with `WithSessionStore`
+
+### Login Flow
+
+1. User visits `/login` → `loginFormPage()` renders a form with a CSRF token
+2. User submits credentials → `loginPostHandler()` validates CSRF token and password
+3. On success, `sess.Set("username", username)` stores the user in the session
+4. User is redirected to `/` which renders `DashboardView`
+
+### DashboardView
+
+- `Mount()` reads `params.Conn.Session.GetString("username")` to display the username
+- `OnSessionExpired()` sets a warning flag and calls `v.Navigate("/login")` to redirect
+
+## Running
+
+```bash
+go run example/auth/auth.go          # http://localhost:8895
+go run example/auth/auth.go -debug   # with debug panel
+```
+
+Login with any username and the password `"password"`. Open multiple tabs to test cross-tab session invalidation.

--- a/example/chat/TUTORIAL.ja.md
+++ b/example/chat/TUTORIAL.ja.md
@@ -1,0 +1,145 @@
+# Chat サンプルチュートリアル
+
+このサンプルは `InfoReceiver`、`Unmounter`、`Session.SendInfo()` を使用して、接続された LiveView セッション間でメッセージをブロードキャストするマルチユーザーリアルタイムチャットルームを実演します。
+
+## 概要
+
+chat サンプルが実装する機能:
+
+- **参加フォーム** — ユーザーがユーザー名を入力してチャットルームに参加
+- **リアルタイムメッセージング** — メッセージが接続中のすべてのユーザーに即座にブロードキャスト
+- **オンラインカウント** — 接続中のユーザー数を表示
+- **システム通知** — 参加/退出イベントをシステムメッセージとして表示
+- **自動スクロール** — チャットが最新メッセージに自動スクロール
+
+## 主要コンセプト
+
+### Hub（Pub/Sub）
+
+`Hub` 構造体（`hub.go`）は接続中の LiveView セッションを追跡し、メッセージをブロードキャストするシンプルな pub/sub です:
+
+```go
+type Hub struct {
+    mu      sync.RWMutex
+    clients map[string]*live.Session
+}
+```
+
+- `Join(sess)` — LiveView セッションを登録
+- `Leave(sessionID)` — セッションを削除
+- `Broadcast(msg, senderID)` — 送信者以外のすべてのセッションに `sess.SendInfo(msg)` 経由でメッセージを送信
+- `OnlineCount()` — 接続中のクライアント数を返す
+
+すべての接続で共有される単一の `Hub` インスタンスを使用します:
+
+```go
+var hub = NewHub()
+```
+
+### InfoReceiver
+
+`InfoReceiver` はサーバーサイドメッセージを受信できる LiveView インターフェースです。他のユーザーがチャットメッセージを送信すると、`HandleInfo()` 経由で配信されます:
+
+```go
+type InfoReceiver interface {
+    View
+    HandleInfo(msg any) error
+}
+```
+
+```go
+func (v *ChatView) HandleInfo(msg any) error {
+    if cm, ok := msg.(ChatMessage); ok {
+        v.Messages = append(v.Messages, cm)
+        v.ScrollIntoPct("#chat-messages", "1.0")
+    }
+    return nil
+}
+```
+
+### Session.SendInfo()
+
+`SendInfo()` は LiveView セッションの info チャネルにメッセージをプッシュします。メッセージは View の `HandleInfo()` メソッドに配信され、再レンダリングがトリガーされます:
+
+```go
+func (h *Hub) Broadcast(msg ChatMessage, senderID string) {
+    for id, sess := range h.clients {
+        if id == senderID {
+            continue
+        }
+        sess.SendInfo(msg)
+    }
+}
+```
+
+### Unmounter
+
+`Unmounter` は WebSocket 接続が閉じられた時（例: ユーザーがタブを閉じた時）に呼ばれます。チャットでは Hub からの退出と退出通知のブロードキャストに使用します:
+
+```go
+type Unmounter interface {
+    Unmount()
+}
+```
+
+```go
+func (v *ChatView) Unmount() {
+    if v.Username != "" && v.session != nil {
+        v.hub.Leave(v.session.ID)
+        v.hub.Broadcast(ChatMessage{
+            Author:  v.Username,
+            Content: fmt.Sprintf("%s left the room", v.Username),
+            System:  true,
+        }, v.session.ID)
+    }
+}
+```
+
+### LiveSession アクセス
+
+`Mount()` メソッドは `params.Conn.LiveSession` から `LiveSession` 参照を保存します。これは `SendInfo()` を提供する `*live.Session` です:
+
+```go
+func (v *ChatView) Mount(params gl.Params) error {
+    v.hub = hub
+    v.session = params.Conn.LiveSession
+    return nil
+}
+```
+
+## ウォークスルー
+
+### chat.go — ChatView
+
+1. **Mount** — 共有 Hub と LiveSession への参照を保存
+2. **HandleEvent** — 3 つのイベントを処理:
+   - `"join"` — ユーザー名を設定し、Hub に参加、参加通知をブロードキャスト
+   - `"input"` — 下書きメッセージテキストを更新
+   - `"send"` / `"keydown"`（Enter） — メッセージをローカルに追加、下書きをクリア、他のユーザーにブロードキャスト
+3. **HandleInfo** — 他のユーザーからの `ChatMessage` を受信し、メッセージリストに追加
+4. **Unmount** — Hub から退出し、退出通知をブロードキャスト
+5. **Render** — `Username` が設定されているかどうかで参加フォームまたはチャット画面を表示
+
+### hub.go — Hub
+
+セッション ID から `*live.Session` へのスレッドセーフなマップです。`Broadcast()` は送信者以外のすべてのクライアントを反復し、`sess.SendInfo(msg)` を呼び出します。
+
+### メッセージフロー
+
+```
+ユーザー A がメッセージを入力
+  → ユーザー A の View で HandleEvent("send")
+  → hub.Broadcast(msg, A.sessionID)
+  → 他の各セッションに対して: sess.SendInfo(msg)
+  → ユーザー B の HandleInfo(msg) が呼ばれる
+  → ユーザー B の View が新しいメッセージで再レンダリング
+```
+
+## 実行方法
+
+```bash
+go run example/chat/chat.go          # http://localhost:8920
+go run example/chat/chat.go -debug   # デバッグパネル付き
+```
+
+複数のブラウザタブを開いて複数ユーザーをシミュレートしてください。各タブで異なるユーザー名で参加できます。

--- a/example/chat/TUTORIAL.md
+++ b/example/chat/TUTORIAL.md
@@ -1,0 +1,145 @@
+# Chat Example Tutorial
+
+This example demonstrates a multi-user real-time chat room using `InfoReceiver`, `Unmounter`, and `Session.SendInfo()` to broadcast messages between connected LiveView sessions.
+
+## Overview
+
+The chat example implements:
+
+- **Join form** — users enter a username to join the chat room
+- **Real-time messaging** — messages are broadcast to all connected users instantly
+- **Online count** — displays the number of connected users
+- **System notifications** — join/leave events are shown as system messages
+- **Auto-scroll** — chat automatically scrolls to the latest message
+
+## Key Concepts
+
+### Hub (Pub/Sub)
+
+The `Hub` struct (`hub.go`) is a simple pub/sub that tracks connected LiveView sessions and broadcasts messages:
+
+```go
+type Hub struct {
+    mu      sync.RWMutex
+    clients map[string]*live.Session
+}
+```
+
+- `Join(sess)` — registers a LiveView session
+- `Leave(sessionID)` — removes a session
+- `Broadcast(msg, senderID)` — sends a message to all sessions except the sender via `sess.SendInfo(msg)`
+- `OnlineCount()` — returns the number of connected clients
+
+A single shared `Hub` instance is used across all connections:
+
+```go
+var hub = NewHub()
+```
+
+### InfoReceiver
+
+`InfoReceiver` is a LiveView interface that allows a View to receive server-side messages. When another user sends a chat message, it is delivered via `HandleInfo()`:
+
+```go
+type InfoReceiver interface {
+    View
+    HandleInfo(msg any) error
+}
+```
+
+```go
+func (v *ChatView) HandleInfo(msg any) error {
+    if cm, ok := msg.(ChatMessage); ok {
+        v.Messages = append(v.Messages, cm)
+        v.ScrollIntoPct("#chat-messages", "1.0")
+    }
+    return nil
+}
+```
+
+### Session.SendInfo()
+
+`SendInfo()` pushes a message to a LiveView session's info channel. The message is delivered to the View's `HandleInfo()` method, triggering a re-render:
+
+```go
+func (h *Hub) Broadcast(msg ChatMessage, senderID string) {
+    for id, sess := range h.clients {
+        if id == senderID {
+            continue
+        }
+        sess.SendInfo(msg)
+    }
+}
+```
+
+### Unmounter
+
+`Unmounter` is called when the WebSocket connection closes (e.g., user closes the tab). The chat uses it to leave the Hub and broadcast a departure notification:
+
+```go
+type Unmounter interface {
+    Unmount()
+}
+```
+
+```go
+func (v *ChatView) Unmount() {
+    if v.Username != "" && v.session != nil {
+        v.hub.Leave(v.session.ID)
+        v.hub.Broadcast(ChatMessage{
+            Author:  v.Username,
+            Content: fmt.Sprintf("%s left the room", v.Username),
+            System:  true,
+        }, v.session.ID)
+    }
+}
+```
+
+### LiveSession Access
+
+The `Mount()` method stores the `LiveSession` reference from `params.Conn.LiveSession`. This is the `*live.Session` that provides `SendInfo()`:
+
+```go
+func (v *ChatView) Mount(params gl.Params) error {
+    v.hub = hub
+    v.session = params.Conn.LiveSession
+    return nil
+}
+```
+
+## Walkthrough
+
+### chat.go — ChatView
+
+1. **Mount** — saves references to the shared Hub and the LiveSession
+2. **HandleEvent** — processes three events:
+   - `"join"` — sets the username, joins the Hub, broadcasts a join notification
+   - `"input"` — updates the draft message text
+   - `"send"` / `"keydown"` (Enter) — appends the message locally, clears the draft, broadcasts to others
+3. **HandleInfo** — receives `ChatMessage` from other users, appends to the message list
+4. **Unmount** — leaves the Hub and broadcasts a leave notification
+5. **Render** — shows either the join form or the chat interface depending on whether `Username` is set
+
+### hub.go — Hub
+
+A thread-safe map of session ID to `*live.Session`. `Broadcast()` iterates over all clients except the sender and calls `sess.SendInfo(msg)`.
+
+### Message Flow
+
+```
+User A types message
+  → HandleEvent("send") on User A's View
+  → hub.Broadcast(msg, A.sessionID)
+  → For each other session: sess.SendInfo(msg)
+  → User B's HandleInfo(msg) is called
+  → User B's View re-renders with the new message
+```
+
+## Running
+
+```bash
+go run example/chat/chat.go          # http://localhost:8920
+go run example/chat/chat.go -debug   # with debug panel
+```
+
+Open multiple browser tabs to simulate multiple users. Each tab can join with a different username.


### PR DESCRIPTION
## Summary
- Add `session/` package documentation (MemoryStore, CSRF helpers, RequireKey auth guard, Broker-based session invalidation)
- Add LiveView advanced interfaces section (InfoReceiver, Unmounter, SessionExpiredHandler, SendInfo)
- Add Transport interface and TestTransport sections
- Add `Skip()` and `HandlerFunc()` to Core Concepts
- Update Handler options table with `WithCheckOrigin` and `WithSessionStore`
- Update CommandQueue commands list with `Navigate`, Styles helpers with `MediaQuery`/`Keyframes`
- Add `auth` and `chat` examples to the examples table and package structure tree
- Create bilingual tutorials (TUTORIAL.md / TUTORIAL.ja.md) for auth and chat examples
- All changes mirrored in both README.md (English) and README.ja.md (Japanese)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Review rendered markdown for formatting correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)