### PR TITLE
Add WebSocket multiplexing and decouple script injection

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/tomo3110/gerbera"
 )
@@ -23,6 +24,7 @@ var gerberaDebugJS []byte
 var gerberaCSS []byte
 
 var jsHash = computeHash(gerberaJS)
+var debugJSHash = computeHash(gerberaDebugJS)
 var cssHash = computeHash(gerberaCSS)
 
 func computeHash(data []byte) string {
@@ -47,9 +49,31 @@ func JSPath() string {
 	return "/_gerbera/js/gerbera." + jsHash + ".js"
 }
 
+// DebugJSPath returns the URL path for gerbera_debug.js with a content hash for cache busting.
+func DebugJSPath() string {
+	return "/_gerbera/js/gerbera_debug." + debugJSHash + ".js"
+}
+
 // CSSPath returns the URL path for gerbera.css with a content hash for cache busting.
 func CSSPath() string {
 	return "/_gerbera/css/gerbera." + cssHash + ".css"
+}
+
+var debugHTMLProvider func() string
+
+// RegisterDebugHTMLProvider sets the callback that provides debug panel HTML.
+// Called by the live package to register its debug panel renderer.
+func RegisterDebugHTMLProvider(fn func() string) {
+	debugHTMLProvider = fn
+}
+
+func escapeForJSString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "</script>", `<\/script>`)
+	return s
 }
 
 // Handler returns an http.Handler that serves gerbera's static assets.
@@ -67,6 +91,18 @@ func Handler() http.Handler {
 		w.Header().Set("Content-Type", "text/css")
 		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
 		w.Write(gerberaCSS)
+	})
+
+	mux.HandleFunc("GET "+DebugJSPath(), func(w http.ResponseWriter, r *http.Request) {
+		js := string(gerberaDebugJS)
+		if debugHTMLProvider != nil {
+			debugHTML := debugHTMLProvider()
+			escaped := escapeForJSString(debugHTML)
+			js = strings.Replace(js, `/*__GERBERA_DEBUG_HTML__*/""`, `"`+escaped+`"`, 1)
+		}
+		w.Header().Set("Content-Type", "application/javascript")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Write([]byte(js))
 	})
 
 	return mux

--- a/assets/files/gerbera.js
+++ b/assets/files/gerbera.js
@@ -808,11 +808,11 @@
           fd.append("files", el.files[i]);
         }
         var liveEl = container;
-        var livePath = liveEl.getAttribute("gerbera-live") || "";
         var liveSid = liveEl._gbLiveSessionId || "";
         var liveCsrf = liveEl._gbLiveCsrf || "";
-        var sep = livePath.indexOf("?") === -1 ? "?" : "&";
-        var url = livePath + sep + "gerbera-upload=1&session=" + liveSid + "&csrf=" + liveCsrf + "&event=" + encodeURIComponent(event);
+        var uploadBase = liveEl._gbMuxEndpoint || liveEl.getAttribute("gerbera-live") || "";
+        var sep = uploadBase.indexOf("?") === -1 ? "?" : "&";
+        var url = uploadBase + sep + "gerbera-upload=1&session=" + liveSid + "&csrf=" + liveCsrf + "&event=" + encodeURIComponent(event);
         fetch(url, {method: "POST", body: fd}).then(function(res) {
           if (res.ok) sendFn("gerbera:upload_complete", {event: event});
         });
@@ -886,6 +886,8 @@
         view.csrf = data.csrf;
         el._gbLiveSessionId = data.session_id;
         el._gbLiveCsrf = data.csrf;
+        // Mark this container as multiplexed so uploads route to the mux endpoint
+        el._gbMuxEndpoint = document.documentElement.getAttribute("gerbera-multiplex");
 
         // Set initial HTML (body content from server)
         el.innerHTML = data.html;

--- a/example/catalog/catalog.go
+++ b/example/catalog/catalog.go
@@ -1919,5 +1919,5 @@ func main() {
 
 	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &CatalogView{} }, opts...))
 	log.Printf("catalog running on %s", *addr)
-	log.Fatal(http.ListenAndServe(*addr, nil))
+	log.Fatal(http.ListenAndServe(*addr, g.Serve(http.DefaultServeMux)))
 }

--- a/example/chat/chat.go
+++ b/example/chat/chat.go
@@ -242,5 +242,5 @@ func main() {
 	}, opts...))
 
 	log.Println("Chat running on http://localhost:8920")
-	log.Fatal(http.ListenAndServe(":8920", nil))
+	log.Fatal(http.ListenAndServe(":8920", g.Serve(http.DefaultServeMux)))
 }

--- a/example/clock/clock.go
+++ b/example/clock/clock.go
@@ -121,5 +121,5 @@ func main() {
 
 	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &ClockView{} }, opts...))
 	log.Printf("clock running on %s", *addr)
-	log.Fatal(http.ListenAndServe(*addr, nil))
+	log.Fatal(http.ListenAndServe(*addr, g.Serve(http.DefaultServeMux)))
 }

--- a/example/counter/counter.go
+++ b/example/counter/counter.go
@@ -56,5 +56,5 @@ func main() {
 
 	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &CounterView{} }, opts...))
 	log.Printf("counter running on %s", *addr)
-	log.Fatal(http.ListenAndServe(*addr, nil))
+	log.Fatal(http.ListenAndServe(*addr, g.Serve(http.DefaultServeMux)))
 }

--- a/example/jscommand/jscommand.go
+++ b/example/jscommand/jscommand.go
@@ -214,5 +214,5 @@ func main() {
 
 	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &JSCommandView{} }, opts...))
 	log.Printf("jscommand running on %s", *addr)
-	log.Fatal(http.ListenAndServe(*addr, nil))
+	log.Fatal(http.ListenAndServe(*addr, g.Serve(http.DefaultServeMux)))
 }

--- a/example/mdviewer/main.go
+++ b/example/mdviewer/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	g "github.com/tomo3110/gerbera"
 	gl "github.com/tomo3110/gerbera/live"
 )
 
@@ -59,5 +60,5 @@ func main() {
 		}
 		log.Printf("  mode: %s, file: %s", mode, filePath)
 	}
-	log.Fatal(http.ListenAndServe(*addr, nil))
+	log.Fatal(http.ListenAndServe(*addr, g.Serve(http.DefaultServeMux)))
 }

--- a/example/sns/main.go
+++ b/example/sns/main.go
@@ -174,10 +174,12 @@ func main() {
 		return NewSettingsView(db, hub)
 	}, liveOpts...)))
 
-	handler := sessionMW(mux)
+	// sessionMW must wrap g.Serve so that /_gerbera/ws (multiplex endpoint)
+	// also has the session loaded into context for authGuard to work.
+	handler := sessionMW(g.Serve(mux, g.WithMultiplex(authGuard(muxHandler))))
 
 	log.Printf("SNS running on http://localhost%s", *addr)
-	log.Fatal(http.ListenAndServe(*addr, g.Serve(handler, g.WithMultiplex(authGuard(muxHandler)))))
+	log.Fatal(http.ListenAndServe(*addr, handler))
 }
 
 // fetchBadgeCounts retrieves notification and message badge counts for the current user.

--- a/example/tabview/tabview.go
+++ b/example/tabview/tabview.go
@@ -113,5 +113,5 @@ func main() {
 
 	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &TabDemoView{} }, opts...))
 	log.Printf("tabview running on %s", *addr)
-	log.Fatal(http.ListenAndServe(*addr, nil))
+	log.Fatal(http.ListenAndServe(*addr, g.Serve(http.DefaultServeMux)))
 }

--- a/example/upload/upload.go
+++ b/example/upload/upload.go
@@ -165,5 +165,5 @@ func main() {
 
 	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &UploadView{} }, opts...))
 	log.Printf("upload running on %s", *addr)
-	log.Fatal(http.ListenAndServe(*addr, nil))
+	log.Fatal(http.ListenAndServe(*addr, g.Serve(http.DefaultServeMux)))
 }

--- a/example/wiki_live/wiki_live.go
+++ b/example/wiki_live/wiki_live.go
@@ -244,5 +244,5 @@ func main() {
 	flag.Parse()
 	http.Handle("/", gl.Handler(func(_ context.Context) gl.View { return &WikiView{} }))
 	log.Printf("wiki_live running on %s", *addr)
-	log.Fatal(http.ListenAndServe(*addr, nil))
+	log.Fatal(http.ListenAndServe(*addr, g.Serve(http.DefaultServeMux)))
 }

--- a/live/debug_panel.go
+++ b/live/debug_panel.go
@@ -160,13 +160,3 @@ func renderDebugPanelHTML() string {
 	})
 	return debugPanelHTMLStr
 }
-
-// escapeForJSString escapes a string for safe embedding inside a JavaScript string literal.
-func escapeForJSString(s string) string {
-	s = strings.ReplaceAll(s, `\`, `\\`)
-	s = strings.ReplaceAll(s, `"`, `\"`)
-	s = strings.ReplaceAll(s, "\n", `\n`)
-	s = strings.ReplaceAll(s, "\r", `\r`)
-	s = strings.ReplaceAll(s, "</script>", `<\/script>`)
-	return s
-}

--- a/live/debug_test.go
+++ b/live/debug_test.go
@@ -28,9 +28,9 @@ func TestDebugHTTPInjectsDebugScript(t *testing.T) {
 	h.ServeHTTP(w, req)
 
 	body := w.Body.String()
-	// gerbera-debug-host is unique to gerbera_debug.js (the DevPanel)
-	if !strings.Contains(body, "gerbera-debug-host") {
-		t.Error("expected debug panel script in response when debug is enabled")
+	// Debug JS is now served as an external script via <script src> tag
+	if !strings.Contains(body, "gerbera_debug.") {
+		t.Error("expected debug panel script src in response when debug is enabled")
 	}
 }
 
@@ -41,8 +41,8 @@ func TestNonDebugHTTPDoesNotInjectDebugScript(t *testing.T) {
 	h.ServeHTTP(w, req)
 
 	body := w.Body.String()
-	// gerbera-debug-host is unique to gerbera_debug.js (the DevPanel)
-	if strings.Contains(body, "gerbera-debug-host") {
+	// Debug JS script src should not be present when debug is disabled
+	if strings.Contains(body, "gerbera_debug.") {
 		t.Error("debug panel script should not be present when debug is disabled")
 	}
 }

--- a/live/handler.go
+++ b/live/handler.go
@@ -4,16 +4,14 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/tomo3110/gerbera"
+	"github.com/tomo3110/gerbera/assets"
 	"github.com/tomo3110/gerbera/diff"
-	"github.com/tomo3110/gerbera/dom"
 	"github.com/tomo3110/gerbera/session"
 )
 
@@ -99,6 +97,12 @@ func Handler(viewFactory func(context.Context) View, opts ...Option) http.Handle
 		o(cfg)
 	}
 
+	if cfg.debug {
+		assets.RegisterDebugHTMLProvider(func() string {
+			return renderDebugPanelHTML()
+		})
+	}
+
 	checkOrigin := cfg.checkOrigin
 	if checkOrigin == nil {
 		checkOrigin = defaultCheckOrigin
@@ -157,9 +161,8 @@ func handleHTTP(w http.ResponseWriter, r *http.Request, viewFactory func(context
 	}
 
 	components := view.Render()
-	components = appendScriptComponents(components, cfg.debug)
-
 	tree := buildTree(cfg.lang, sess.ID, sess.CSRFToken, components)
+	registerScripts(tree, cfg.debug)
 
 	sess.mu.Lock()
 	sess.tree = tree
@@ -235,7 +238,6 @@ func handleWS(w http.ResponseWriter, r *http.Request, store *sessionStore, cfg *
 // When debug is true, it also marshals the View state for the debug panel.
 func renderAndDiff(sess *Session, cfg *handlerConfig) ([]diff.Patch, []JSCommand, json.RawMessage) {
 	components := sess.View.Render()
-	components = appendScriptComponents(components, cfg.debug)
 	lang := ""
 	if sess.tree != nil {
 		for _, a := range sess.tree.Attributes() {
@@ -265,25 +267,17 @@ func renderAndDiff(sess *Session, cfg *handlerConfig) ([]diff.Patch, []JSCommand
 	return patches, cmds, viewState
 }
 
-// appendScriptComponents appends gerbera JS (and debug JS when enabled)
-// as a second <body> component. Both handleHTTP and renderAndDiff call this
-// so that old and new trees always share the same structure, preventing
-// spurious diff patches for the script body.
-func appendScriptComponents(components gerbera.Components, debug bool) gerbera.Components {
+// registerScripts registers gerbera.js (and debug JS when enabled) as
+// metadata on the tree root, so that gerbera.Render() injects <script src>
+// tags in the <body>. diff.Diff() and diff.RenderFragment() ignore metadata,
+// keeping the ViewLoop tree free of scripts.
+func registerScripts(tree *gerbera.Element, debug bool) {
+	jsURL, _ := url.Parse(assets.JSPath())
+	assets.RequireScript(tree, jsURL)
 	if debug {
-		debugHTML := renderDebugPanelHTML()
-		escaped := escapeForJSString(debugHTML)
-		debugJS := strings.Replace(gerberaDebugJSContent(),
-			`/*__GERBERA_DEBUG_HTML__*/""`,
-			`"`+escaped+`"`, 1)
-		return append(components, dom.Body(
-			gerbera.Literal(fmt.Sprintf("<script>%s</script>", gerberaJSContent())),
-			gerbera.Literal(fmt.Sprintf("<script>%s</script>", debugJS)),
-		))
+		debugURL, _ := url.Parse(assets.DebugJSPath())
+		assets.RequireScript(tree, debugURL)
 	}
-	return append(components, dom.Body(
-		gerbera.Literal(fmt.Sprintf("<script>%s</script>", gerberaJSContent())),
-	))
 }
 
 // buildTree creates the full <html> Element tree from view components.

--- a/live/handler_test.go
+++ b/live/handler_test.go
@@ -66,8 +66,8 @@ func TestHandlerHTTPRender(t *testing.T) {
 	if !strings.Contains(body, "gerbera-click") {
 		t.Error("expected gerbera-click attribute in response")
 	}
-	if !strings.Contains(body, "<script>") {
-		t.Error("expected embedded script tag")
+	if !strings.Contains(body, `<script src="`) {
+		t.Error("expected script src tag for gerbera.js")
 	}
 }
 

--- a/live/js.go
+++ b/live/js.go
@@ -7,9 +7,3 @@ import "github.com/tomo3110/gerbera/assets"
 func gerberaJSContent() string {
 	return assets.JSString()
 }
-
-// gerberaDebugJSContent returns the debug panel JavaScript content.
-// The single source of truth is assets/files/gerbera_debug.js.
-func gerberaDebugJSContent() string {
-	return assets.DebugJSString()
-}

--- a/live/loop.go
+++ b/live/loop.go
@@ -75,9 +75,9 @@ func ViewLoop(view View, transport Transport, cfg ViewLoopConfig) error {
 	}
 
 	// Build the initial tree so that the first diff has a baseline.
-	// Include script components so the tree matches what handleHTTP sent.
+	// Scripts are no longer in the tree — they are injected via metadata
+	// only at gerbera.Render() time, so the diff baseline is script-free.
 	components := view.Render()
-	components = appendScriptComponents(components, cfg.Debug)
 	sess.tree = buildTree(cfg.Lang, cfg.SessionID, cfg.CSRFToken, components)
 
 	hcfg := &handlerConfig{

--- a/live/multiplex.go
+++ b/live/multiplex.go
@@ -2,7 +2,9 @@ package live
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -85,6 +87,14 @@ type MultiplexHandler struct {
 	cfg      *handlerConfig
 	upgrader *websocket.Upgrader
 	dlog     *debugLogger
+	sessions sync.Map // sessionID → *muxSessionEntry
+}
+
+// muxSessionEntry tracks a session registered by a multiplexed view
+// for upload support.
+type muxSessionEntry struct {
+	sess *Session
+	view View
 }
 
 // NewMultiplexHandler creates a new MultiplexHandler backed by the given registry.
@@ -111,13 +121,83 @@ func NewMultiplexHandler(registry *ViewRegistry, opts ...Option) *MultiplexHandl
 }
 
 func (h *MultiplexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Handle file uploads via POST
+	if r.URL.Query().Get("gerbera-upload") == "1" && r.Method == http.MethodPost {
+		h.handleUpload(w, r)
+		return
+	}
+
 	conn, err := h.upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return
 	}
 
-	mc := newMultiplexConn(conn, h.registry, h.cfg, h.dlog, r)
+	mc := newMultiplexConn(conn, h.registry, h.cfg, h.dlog, r, &h.sessions)
 	mc.run()
+}
+
+// handleUpload processes file uploads for multiplexed views.
+func (h *MultiplexHandler) handleUpload(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.URL.Query().Get("session")
+	val, ok := h.sessions.Load(sessionID)
+	if !ok {
+		http.Error(w, "session not found", http.StatusNotFound)
+		return
+	}
+	entry := val.(*muxSessionEntry)
+
+	// Validate CSRF token
+	csrfToken := r.URL.Query().Get("csrf")
+	if subtle.ConstantTimeCompare([]byte(csrfToken), []byte(entry.sess.CSRFToken)) != 1 {
+		http.Error(w, "invalid CSRF token", http.StatusForbidden)
+		return
+	}
+
+	uh, ok := entry.view.(UploadHandler)
+	if !ok {
+		http.Error(w, "view does not support uploads", http.StatusBadRequest)
+		return
+	}
+
+	event := r.URL.Query().Get("event")
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		http.Error(w, "failed to parse multipart form", http.StatusBadRequest)
+		return
+	}
+
+	var files []UploadedFile
+	for _, fHeaders := range r.MultipartForm.File {
+		for _, fh := range fHeaders {
+			f, err := fh.Open()
+			if err != nil {
+				continue
+			}
+			data, err := io.ReadAll(f)
+			f.Close()
+			if err != nil {
+				continue
+			}
+			files = append(files, UploadedFile{
+				Name:     fh.Filename,
+				Size:     fh.Size,
+				MIMEType: fh.Header.Get("Content-Type"),
+				Data:     data,
+			})
+		}
+	}
+
+	entry.sess.mu.Lock()
+	err := uh.HandleUpload(event, files)
+	entry.sess.mu.Unlock()
+
+	if err != nil {
+		h.dlog.handleError(sessionID, "HandleUpload", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"ok":true}`))
 }
 
 // --- renderAndDiffForMux renders a view's body and returns HTML/patches ---

--- a/live/multiplex_conn.go
+++ b/live/multiplex_conn.go
@@ -27,6 +27,7 @@ type multiplexConn struct {
 	cfg      *handlerConfig
 	dlog     *debugLogger
 	req      *http.Request // original upgrade request (for session, etc.)
+	sessions *sync.Map     // shared session store for upload support
 
 	mu    sync.Mutex
 	views map[string]*muxViewEntry
@@ -35,13 +36,14 @@ type multiplexConn struct {
 	done  chan struct{}
 }
 
-func newMultiplexConn(conn *websocket.Conn, registry *ViewRegistry, cfg *handlerConfig, dlog *debugLogger, r *http.Request) *multiplexConn {
+func newMultiplexConn(conn *websocket.Conn, registry *ViewRegistry, cfg *handlerConfig, dlog *debugLogger, r *http.Request, sessions *sync.Map) *multiplexConn {
 	return &multiplexConn{
 		conn:     conn,
 		registry: registry,
 		cfg:      cfg,
 		dlog:     dlog,
 		req:      r,
+		sessions: sessions,
 		views:    make(map[string]*muxViewEntry),
 		outCh:    make(chan outboundMsg, 64),
 		done:     make(chan struct{}),
@@ -191,6 +193,9 @@ func (mc *multiplexConn) handleMount(msg MultiplexClientMessage) {
 
 	transport := newMultiplexTransport(msg.ViewID, mc.outCh)
 
+	// Register session for upload support
+	mc.sessions.Store(sess.ID, &muxSessionEntry{sess: sess, view: view})
+
 	mc.mu.Lock()
 	mc.views[msg.ViewID] = &muxViewEntry{vs: vs, transport: transport}
 	mc.mu.Unlock()
@@ -230,6 +235,7 @@ func (mc *multiplexConn) handleMount(msg MultiplexClientMessage) {
 		}
 
 		transport.Close()
+		mc.sessions.Delete(sess.ID)
 
 		mc.mu.Lock()
 		delete(mc.views, msg.ViewID)
@@ -286,6 +292,7 @@ func (mc *multiplexConn) cleanupAll() {
 	for _, e := range entries {
 		e.transport.Close()
 		e.vs.cancel()
+		mc.sessions.Delete(e.vs.sess.ID)
 	}
 
 	// Give ViewLoops time to run Unmount


### PR DESCRIPTION
## Summary
- Add WebSocket multiplexing for LiveMount, allowing multiple LiveView components on the same page to share a single WebSocket connection (Issue #50)
- Consolidate JS files from `live/` to `assets/files/` as single source of truth
- Decouple script injection from ViewLoop by replacing inline `<script>` injection (`appendScriptComponents`) with the existing `assets.RequireScript` metadata mechanism, making the ViewLoop diff tree script-free for non-browser environments (e.g. Wails)
- Add file upload support for multiplexed views
- Fix all LiveView examples to use `g.Serve()` for asset delivery

## Key changes

### WebSocket Multiplexing (Issue #50)
- `live/multiplex.go`: `MultiplexHandler`, `ViewRegistry`, `MultiplexServerMessage`/`MultiplexClientMessage` wire types
- `live/multiplex_conn.go`: Per-connection management with read/write goroutines, per-view transports
- `live/multiplex_transport.go`: `MultiplexTransport` implementing `Transport` interface
- `live/mount.go`: `MultiplexAttr()`, `WithIndependentConnection()` options
- `serve.go`: `WithMultiplex()` option for `g.Serve()`
- `assets/files/gerbera.js`: `GerberaMultiplex` client-side multiplexing logic

### Script Injection Decoupling
- `assets/assets.go`: Add `DebugJSPath()`, `RegisterDebugHTMLProvider()`, and debug JS endpoint for external script serving
- `live/handler.go`: Replace `appendScriptComponents` with `registerScripts()` using `RequireScript` metadata; scripts are now `<script src>` tags injected only at `gerbera.Render()` time
- `live/loop.go`: Remove `appendScriptComponents` from ViewLoop initialization — diff baseline is now script-free
- `live/js.go`: Remove `gerberaDebugJSContent()` (no longer needed)
- `live/debug_panel.go`: Move `escapeForJSString` to `assets` package

### Multiplexed File Upload Support
- `live/multiplex.go`: Add shared session store (`sync.Map`) to `MultiplexHandler`; handle upload POST requests in `ServeHTTP`
- `live/multiplex_conn.go`: Register/unregister sessions on mount/unmount/cleanup
- `assets/files/gerbera.js`: Multiplexed containers store `_gbMuxEndpoint` so uploads route to `/_gerbera/ws`

### Example Fixes
- `example/sns/main.go`: Apply `sessionMW` outside `g.Serve()` so `/_gerbera/ws` has session context for `authGuard`
- 9 Full LiveView examples (counter, clock, jscommand, upload, wiki_live, mdviewer, tabview, chat, catalog): Wrap with `g.Serve(http.DefaultServeMux)` for `/_gerbera/` asset delivery

## Test plan
- [x] `go test ./...` — all tests pass
- [x] `go run example/counter/counter.go` — Full LiveView 動作確認
- [x] `go run example/counter/counter.go -debug` — debug パネル動作確認
- [x] `cd example/sns && docker compose up` — SNS マルチプレクス動作確認
- [x] SNS Settings 画面でアバター画像のアップロードが成功することを確認
- [x] ブラウザ DevTools で `<script src="/_gerbera/js/gerbera.*.js" defer>` が存在することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)